### PR TITLE
build: add pyproject.toml with mcp and pycubrid deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,89 @@
+[build-system]
+requires = ["setuptools>=65.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cubrid-mcp-server"
+version = "0.1.0"
+description = "Model Context Protocol server for CUBRID database"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    {name = "Gyeongjun Paik", email = "paikend@gmail.com"},
+]
+keywords = ["CUBRID", "database", "MCP", "Model Context Protocol", "LLM"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Database :: Front-Ends",
+]
+dependencies = [
+    "mcp>=1.0",
+    "pycubrid>=1.0",
+    "sqlparse>=0.5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov",
+    "ruff==0.15.8",
+    "mypy==1.19.1",
+    "bandit[toml]==1.9.4",
+    "pre-commit",
+    "tox",
+]
+
+[project.scripts]
+cubrid-mcp-server = "cubrid_mcp_server.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/paikend/cubrid-mcp-server"
+Repository = "https://github.com/paikend/cubrid-mcp-server"
+Issues = "https://github.com/paikend/cubrid-mcp-server/issues"
+
+[tool.setuptools]
+packages = ["cubrid_mcp_server"]
+include-package-data = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint.isort]
+known-first-party = ["cubrid_mcp_server"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
+[tool.coverage.run]
+source = ["cubrid_mcp_server"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 95
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--tb native -v -r fxX --maxfail=25 -p no:warnings"
+python_files = "tests/*test_*.py"


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` so the project is installable and declares its dev tooling.
- Runtime deps: `mcp>=1.0`, `pycubrid>=1.0`, `sqlparse>=0.5` (sqlparse is for the read-only safety checker in a follow-up PR).
- Dev extras, ruff/mypy/bandit/pytest-cov config, and coverage `fail_under = 95` mirror [`cubrid-labs/pycubrid`](https://github.com/cubrid-labs/pycubrid/blob/main/pyproject.toml) so tone-and-manner stays consistent when this repo joins the org.
- Declares the `cubrid-mcp-server` console script (`cubrid_mcp_server.__main__:main`) — target module arrives in a later PR.

## Test plan
- [x] `pyproject.toml` parses as valid TOML.
- [ ] `pip install -e .[dev]` succeeds (deferred until source modules exist).
- [ ] `ruff check` / `mypy` / `pytest` run clean (deferred until source modules exist).

Closes #9
Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)