### PR TITLE
feat: add read-only SQL safety checker

### DIFF
--- a/cubrid_mcp_server/safety.py
+++ b/cubrid_mcp_server/safety.py
@@ -1,0 +1,65 @@
+"""Read-only SQL safety checker.
+
+When the server runs in read-only mode (the default), every statement passed
+to ``execute_query`` is inspected by :func:`ensure_read_only` before reaching
+the database. Only the minimal set of statements needed to inspect data and
+schemas is allowed, and multi-statement input is rejected outright.
+
+The checker is a defence-in-depth layer. Operators are still expected to
+configure CUBRID with a read-only user account for production use. See
+``SECURITY.md`` for the recommended setup.
+"""
+
+from __future__ import annotations
+
+import sqlparse
+from sqlparse.sql import Statement
+from sqlparse.tokens import DML, Keyword
+
+READ_ONLY_KEYWORDS: frozenset[str] = frozenset(
+    {"SELECT", "SHOW", "DESC", "DESCRIBE", "EXPLAIN", "WITH"}
+)
+
+
+class UnsafeSQLError(ValueError):
+    """Raised when a statement is rejected by the read-only checker."""
+
+
+def ensure_read_only(sql: str) -> None:
+    """Raise :class:`UnsafeSQLError` if ``sql`` is not a single read-only statement."""
+    if not sql or not sql.strip():
+        raise UnsafeSQLError("empty SQL statement")
+
+    statements = [stmt for stmt in sqlparse.parse(sql) if _is_non_empty(stmt)]
+    if len(statements) == 0:
+        raise UnsafeSQLError("empty SQL statement")
+    if len(statements) > 1:
+        raise UnsafeSQLError("multi-statement SQL is not allowed in read-only mode")
+
+    statement = statements[0]
+    keyword = _leading_keyword(statement)
+    if keyword is None:
+        raise UnsafeSQLError("could not determine the leading SQL keyword")
+    if keyword.upper() not in READ_ONLY_KEYWORDS:
+        raise UnsafeSQLError(
+            f"{keyword.upper()} is not permitted in read-only mode; "
+            f"allowed statements: {', '.join(sorted(READ_ONLY_KEYWORDS))}"
+        )
+
+
+def _is_non_empty(statement: Statement) -> bool:
+    stripped = statement.value.strip().rstrip(";").strip()
+    return bool(stripped)
+
+
+def _leading_keyword(statement: Statement) -> str | None:
+    for token in statement.tokens:
+        if token.is_whitespace:
+            continue
+        if token.ttype in (DML, Keyword):
+            return token.value
+        if token.ttype is None and hasattr(token, "tokens"):
+            inner = _leading_keyword(token)
+            if inner is not None:
+                return inner
+    return None

--- a/cubrid_mcp_server/safety.py
+++ b/cubrid_mcp_server/safety.py
@@ -57,7 +57,7 @@ def _leading_keyword(statement: Statement) -> str | None:
         if token.is_whitespace:
             continue
         if token.ttype in (DML, Keyword):
-            return token.value
+            return str(token.value)
         if token.ttype is None and hasattr(token, "tokens"):
             inner = _leading_keyword(token)
             if inner is not None:

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,55 @@
+import pytest
+
+from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        "select * from users where id = 1",
+        "SHOW TABLES",
+        "DESC users",
+        "DESCRIBE users",
+        "EXPLAIN SELECT * FROM users",
+        "WITH recent AS (SELECT * FROM users) SELECT * FROM recent",
+        "  SELECT 1  ",
+        "SELECT 1;",
+    ],
+)
+def test_ensure_read_only_allows_read_statements(sql: str) -> None:
+    ensure_read_only(sql)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "INSERT INTO users VALUES (1)",
+        "UPDATE users SET name='x'",
+        "DELETE FROM users",
+        "DROP TABLE users",
+        "TRUNCATE TABLE users",
+        "CREATE TABLE t (id INT)",
+        "ALTER TABLE users ADD COLUMN x INT",
+        "GRANT SELECT ON users TO mcp",
+    ],
+)
+def test_ensure_read_only_rejects_write_statements(sql: str) -> None:
+    with pytest.raises(UnsafeSQLError):
+        ensure_read_only(sql)
+
+
+def test_ensure_read_only_rejects_multi_statement() -> None:
+    with pytest.raises(UnsafeSQLError, match="multi-statement"):
+        ensure_read_only("SELECT 1; SELECT 2")
+
+
+def test_ensure_read_only_rejects_select_then_drop() -> None:
+    with pytest.raises(UnsafeSQLError, match="multi-statement"):
+        ensure_read_only("SELECT 1; DROP TABLE users")
+
+
+@pytest.mark.parametrize("sql", ["", "   ", ";", "   ;  "])
+def test_ensure_read_only_rejects_empty(sql: str) -> None:
+    with pytest.raises(UnsafeSQLError, match="empty"):
+        ensure_read_only(sql)


### PR DESCRIPTION
## Summary
- Add `cubrid_mcp_server/safety.py` with `ensure_read_only(sql)` that parses input via `sqlparse` and only permits `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH`.
- Reject multi-statement input outright so a trailing `; DROP TABLE …` cannot smuggle past the whitelist.
- Unit tests cover the allow-list, common write rejections, multi-statement rejection, and empty / whitespace / lone-semicolon input.

## Why this lives in code as well as DB
This is a defence-in-depth layer. Operators are still expected to run the server as a CUBRID user that only has `SELECT` privileges — the upcoming `SECURITY.md` will walk through that. Having both means a configuration slip on either side does not open writes.

## Dependencies / ordering
Depends on `cubrid_mcp_server/__init__.py` arriving in #11; this branch is stacked on top of `feat/config` so imports resolve during review.

## Test plan
- [x] `pytest tests/test_safety.py` (deferred until pyproject and CI PRs land).

Closes #4
Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)