### PR TITLE
feat: add pycubrid connection layer

### DIFF
--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -1,0 +1,62 @@
+"""Thin wrapper around pycubrid for the MCP server."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Iterator
+
+import pycubrid
+
+from cubrid_mcp_server.config import Config
+
+if TYPE_CHECKING:
+    from pycubrid import Connection, Cursor
+
+
+class DatabaseError(RuntimeError):
+    """Raised when a database operation fails."""
+
+
+class Database:
+    """Lazily opens and reuses a single pycubrid connection."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._connection: "Connection | None" = None
+
+    def connect(self) -> "Connection":
+        if self._connection is None:
+            try:
+                self._connection = pycubrid.connect(
+                    host=self._config.host,
+                    port=self._config.port,
+                    user=self._config.user,
+                    password=self._config.password,
+                    db=self._config.database,
+                )
+            except Exception as exc:  # pragma: no cover - driver-specific
+                raise DatabaseError(f"failed to connect to CUBRID: {exc}") from exc
+        return self._connection
+
+    def close(self) -> None:
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            finally:
+                self._connection = None
+
+    @contextmanager
+    def cursor(self) -> Iterator["Cursor"]:
+        connection = self.connect()
+        cursor = connection.cursor()
+        try:
+            yield cursor
+        except Exception as exc:
+            raise DatabaseError(f"query failed: {exc}") from exc
+        finally:
+            cursor.close()
+
+    def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
+        with self.cursor() as cursor:
+            cursor.execute(sql, params or ())
+            return list(cursor.fetchall())

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import Any, Iterator
 
 import pycubrid
 
 from cubrid_mcp_server.config import Config
-
-if TYPE_CHECKING:
-    from pycubrid import Connection, Cursor
 
 
 class DatabaseError(RuntimeError):
@@ -22,9 +19,9 @@ class Database:
 
     def __init__(self, config: Config) -> None:
         self._config = config
-        self._connection: "Connection | None" = None
+        self._connection: Any = None
 
-    def connect(self) -> "Connection":
+    def connect(self) -> Any:
         if self._connection is None:
             try:
                 self._connection = pycubrid.connect(
@@ -46,7 +43,7 @@ class Database:
                 self._connection = None
 
     @contextmanager
-    def cursor(self) -> Iterator["Cursor"]:
+    def cursor(self) -> Iterator[Any]:
         connection = self.connect()
         cursor = connection.cursor()
         try:


### PR DESCRIPTION
## Summary
- Add `cubrid_mcp_server/database.py` — a `Database` class that lazily opens a single `pycubrid` connection.
- Exposes a `cursor()` context manager and a `fetch_all()` helper. Driver errors surface as `DatabaseError` so the MCP tool layer can return structured failures.

## Ordering
Stacked on top of `feat/safety` (which is stacked on `feat/config`), so imports resolve during review. Can merge in any order after those land.

## Test plan
- [ ] Connecting to a local CUBRID instance is manually smoke-tested after `pyproject` + this PR merge.

Closes #5
Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)