### PR TITLE
ci: add GitHub Actions workflow (lint + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install project and dev tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff (lint)
+        run: ruff check .
+
+      - name: Ruff (format check)
+        run: ruff format --check .
+
+      - name: Mypy (strict)
+        run: mypy cubrid_mcp_server
+
+      - name: Bandit (security)
+        run: bandit -c pyproject.toml -r cubrid_mcp_server
+
+      - name: Pytest
+        run: pytest


### PR DESCRIPTION
## Summary
- Add \`.github/workflows/ci.yml\` running ruff (lint + format check), mypy strict, bandit, and pytest.
- Matrix covers Python 3.10 through 3.13 to match the classifiers declared in \`pyproject.toml\`.
- Uses pip caching keyed on \`pyproject.toml\` for faster reruns.

## Ordering
Depends on \`pyproject.toml\` (#10) being available on \`main\` so \`pip install -e .[dev]\` can resolve. Safe to merge after the pyproject PR.

## Test plan
- [ ] First green run after \`pyproject.toml\` (+ source modules) lands on \`main\`.

Closes #8
Part of #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)