### PR TITLE
fix: set version to 0.0.1 and switch dep to fastmcp

### DIFF
--- a/cubrid_mcp_server/__init__.py
+++ b/cubrid_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Model Context Protocol server for CUBRID database."""
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubrid-mcp-server"
-version = "0.1.0"
+version = "0.0.1"
 description = "Model Context Protocol server for CUBRID database"
 readme = "README.md"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["CUBRID", "database", "MCP", "Model Context Protocol", "LLM"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 2 - Pre-Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Database :: Front-Ends",
 ]
 dependencies = [
-    "mcp>=1.0",
+    "fastmcp>=2.0",
     "pycubrid>=1.0",
     "sqlparse>=0.5",
 ]


### PR DESCRIPTION
## Summary
- Fix version `0.1.0` → `0.0.1` in both `pyproject.toml` and `__init__.py`
- Switch `Development Status :: 3 - Alpha` → `2 - Pre-Alpha`
- Switch runtime dep `mcp>=1.0` → `fastmcp>=2.0` ([jlowin/fastmcp](https://github.com/jlowin/fastmcp))

## Why
The original pyproject.toml PR was merged before the amendment that added these changes. This PR applies the corrections on top of the merged state.

## Test plan
- [x] `pyproject.toml` is valid TOML
- [x] `__init__.__version__` matches `pyproject.toml` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)