### PR TITLE
fix: correct pycubrid connect param and schema_definitions query

### DIFF
--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -29,7 +29,7 @@ class Database:
                     port=self._config.port,
                     user=self._config.user,
                     password=self._config.password,
-                    db=self._config.database,
+                    database=self._config.database,
                 )
             except Exception as exc:  # pragma: no cover - driver-specific
                 raise DatabaseError(f"failed to connect to CUBRID: {exc}") from exc

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -47,20 +47,32 @@ def schema_definitions(table_name: str) -> list[dict[str, Any]]:
     """Return column metadata for ``table_name``: name, type, nullability, default, PK flag."""
     rows = _db().fetch_all(
         """
-        SELECT attr_name, data_type, is_nullable, default_value, key_type
-        FROM db_attribute
-        WHERE class_name = ?
-        ORDER BY def_order
+        SELECT a.attr_name, a.data_type, a.is_nullable, a.default_value
+        FROM db_attribute a
+        WHERE a.class_name = ?
+        ORDER BY a.def_order
         """,
         (table_name,),
     )
+    pk_rows = _db().fetch_all(
+        """
+        SELECT k.key_attr_name
+        FROM db_index i, db_index_key k
+        WHERE i.class_name = ?
+          AND i.is_primary_key = 'YES'
+          AND i.index_name = k.index_name
+          AND i.class_name = k.class_name
+        """,
+        (table_name,),
+    )
+    pk_columns: set[str] = {r[0] for r in pk_rows}
     return [
         {
             "name": row[0],
             "type": row[1],
             "nullable": row[2] == "YES",
             "default": row[3],
-            "primary_key": row[4] == "PRI",
+            "primary_key": row[0] in pk_columns,
         }
         for row in rows
     ]


### PR DESCRIPTION
## Summary
- **database.py**: `db=` → `database=` for `pycubrid.connect()` — `db` silently fell into `**kwargs`, sending an empty database name (error code 8999)
- **server.py**: `db_attribute.key_type` column does not exist in CUBRID 11.2; replaced with `db_index`/`db_index_key` join for primary key detection

## How it was found
Smoke test against real CUBRID 11.2 demodb (Docker + colima). All 4 MCP tools now verified working end-to-end.

## Test plan
- [x] 32 unit tests passing
- [x] ruff check + format clean
- [x] mypy strict clean
- [x] Smoke test: all_table_names, filter_table_names, schema_definitions, execute_query against CUBRID 11.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)