### PR TITLE
chore: update URLs from paikend to cubrid-labs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,6 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 
 ## Quick Start
 
-### Install
-
-```bash
-pip install cubrid-mcp-server
-```
-
-Or install from source:
-
-```bash
-git clone https://github.com/paikend/cubrid-mcp-server.git
-cd cubrid-mcp-server
-pip install -e .
-```
-
 ### Configure
 
 Set the required environment variables:
@@ -48,8 +34,16 @@ Optional settings:
 
 ### Run
 
+No installation required — use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to run directly from PyPI:
+
 ```bash
-cubrid-mcp-server
+uvx cubrid-mcp-server
+```
+
+Or with `pipx`:
+
+```bash
+pipx run cubrid-mcp-server
 ```
 
 ## MCP Client Integration
@@ -62,7 +56,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "cubrid": {
-      "command": "cubrid-mcp-server",
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
         "CUBRID_USER": "dba",
@@ -82,7 +77,8 @@ Add to `.mcp.json` in your project root:
 {
   "mcpServers": {
     "cubrid": {
-      "command": "cubrid-mcp-server",
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
         "CUBRID_USER": "dba",
@@ -102,7 +98,8 @@ Add to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "cubrid": {
-      "command": "cubrid-mcp-server",
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
         "CUBRID_USER": "dba",
@@ -123,7 +120,7 @@ For production use, also configure a read-only database user. See [`SECURITY.md`
 ## Development
 
 ```bash
-git clone https://github.com/paikend/cubrid-mcp-server.git
+git clone https://github.com/cubrid-labs/cubrid-mcp-server.git
 cd cubrid-mcp-server
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ dev = [
 cubrid-mcp-server = "cubrid_mcp_server.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/paikend/cubrid-mcp-server"
-Repository = "https://github.com/paikend/cubrid-mcp-server"
-Issues = "https://github.com/paikend/cubrid-mcp-server/issues"
+Homepage = "https://github.com/cubrid-labs/cubrid-mcp-server"
+Repository = "https://github.com/cubrid-labs/cubrid-mcp-server"
+Issues = "https://github.com/cubrid-labs/cubrid-mcp-server/issues"
 
 [tool.setuptools]
 packages = ["cubrid_mcp_server"]


### PR DESCRIPTION
## Summary
- Update all repository URLs from `paikend/cubrid-mcp-server` to `cubrid-labs/cubrid-mcp-server`
- Switch README to use `uvx` as primary run method (MCP standard practice)

## Changed files
- `pyproject.toml`: Homepage, Repository, Issues URLs
- `README.md`: git clone URL, Quick Start and all MCP client examples updated to `uvx`

## Test plan
- [x] No code changes, documentation only
- [x] All URLs point to cubrid-labs org

🤖 Generated with [Claude Code](https://claude.com/claude-code)