### PR TITLE
feat: v0.1.0 tool expansion (6 new MCP tools)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,21 +50,6 @@ jobs:
   integration:
     runs-on: ubuntu-latest
 
-    services:
-      cubrid:
-        image: cubrid/cubrid:11.2
-        env:
-          CUBRID_DB: demodb
-        ports:
-          - 33000:33000
-        options: >-
-          --health-cmd "cubrid broker status || true"
-          --health-interval 15s
-          --health-timeout 10s
-          --health-retries 10
-          --health-start-period 60s
-          --shm-size 512m
-
     steps:
       - uses: actions/checkout@v4
 
@@ -80,9 +65,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Start CUBRID container
+        run: |
+          docker run -d --name cubrid \
+            --shm-size 512m \
+            -p 33000:33000 \
+            -p 1523:1523 \
+            cubrid/cubrid:11.2
+          docker ps
+
       - name: Wait for CUBRID broker
         run: |
-          for i in $(seq 1 90); do
+          for i in $(seq 1 60); do
             if python -c "
           import socket
           s = socket.socket()
@@ -91,16 +85,17 @@ jobs:
               s.connect(('127.0.0.1', 33000))
               s.close()
               exit(0)
-          except:
+          except Exception:
               exit(1)
           " 2>/dev/null; then
-              echo "CUBRID broker is ready"
+              echo "CUBRID broker is ready (attempt $i)"
               exit 0
             fi
             echo "Waiting for CUBRID... attempt $i"
             sleep 5
           done
           echo "CUBRID broker did not start in time"
+          docker logs cubrid || true
           exit 1
 
       - name: Pytest (integration)
@@ -111,3 +106,7 @@ jobs:
           CUBRID_PASSWORD: ""
           CUBRID_DATABASE: demodb
         run: pytest -m integration -v
+
+      - name: CUBRID logs (on failure)
+        if: failure()
+        run: docker logs cubrid || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Mypy (strict)
         run: mypy cubrid_mcp_server
 
-      - name: Bandit (security)
-        run: bandit -c pyproject.toml -r cubrid_mcp_server
-
       - name: Pytest (unit)
         run: pytest -m "not integration"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,32 +69,23 @@ jobs:
         run: |
           docker run -d --name cubrid \
             --shm-size 512m \
+            -e CUBRID_DB=demodb \
             -p 33000:33000 \
             -p 1523:1523 \
             cubrid/cubrid:11.2
           docker ps
 
-      - name: Wait for CUBRID broker
+      - name: Wait for CUBRID demodb to be ready
         run: |
           for i in $(seq 1 60); do
-            if python -c "
-          import socket
-          s = socket.socket()
-          s.settimeout(2)
-          try:
-              s.connect(('127.0.0.1', 33000))
-              s.close()
-              exit(0)
-          except Exception:
-              exit(1)
-          " 2>/dev/null; then
-              echo "CUBRID broker is ready (attempt $i)"
+            if docker exec cubrid bash -lc "csql -u dba demodb -c 'SELECT 1;'" >/dev/null 2>&1; then
+              echo "CUBRID demodb is ready (attempt $i)"
               exit 0
             fi
-            echo "Waiting for CUBRID... attempt $i"
+            echo "Waiting for CUBRID demodb... attempt $i"
             sleep 5
           done
-          echo "CUBRID broker did not start in time"
+          echo "CUBRID demodb did not become ready in time"
           docker logs cubrid || true
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Wait for CUBRID broker
         run: |
-          for i in $(seq 1 30); do
+          for i in $(seq 1 90); do
             if python -c "
           import socket
           s = socket.socket()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
       id-token: write
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 | `all_table_names` | List every user table in the database |
 | `filter_table_names` | Substring search over table names |
 | `schema_definitions` | Column types, nullability, defaults, and primary key info |
+| `describe_table` | Full metadata: columns, primary key, and indexes in one call |
+| `list_indexes` | Indexes for a table with key columns and flags |
+| `explain_query` | Execution plan/trace for a `SELECT`/`WITH` (via CUBRID `SHOW TRACE`) |
+| `table_row_counts` | `COUNT(*)` for one or many tables |
+| `list_serials` | CUBRID `SERIAL` sequences with current value and bounds |
+| `list_class_hierarchy` | CUBRID `CLASS` inheritance relationships |
 | `execute_query` | Run read-only SQL with automatic output truncation |
 
 ## Quick Start

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -9,6 +10,8 @@ from fastmcp import FastMCP
 from cubrid_mcp_server.config import Config
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
+
+logger = logging.getLogger(__name__)
 
 mcp = FastMCP("cubrid-mcp-server")
 
@@ -148,31 +151,48 @@ def explain_query(sql: str) -> dict[str, Any]:
             if trace_rows and trace_rows[0]:
                 plan = str(trace_rows[0][0] or "").strip()
     finally:
-        try:
-            with db.cursor() as cur:
-                cur.execute("SET TRACE OFF", ())
-        except Exception:
-            pass
-        try:
-            db.connect().rollback()
-        except Exception:
-            pass
+        _reset_trace_state(db)
 
     return {"sql": cleaned, "plan": plan}
+
+
+def _reset_trace_state(db: Database) -> None:
+    """Best-effort cleanup of ``SET TRACE`` session state and pending transaction."""
+    cleanup_errors: list[str] = []
+    try:
+        with db.cursor() as cur:
+            cur.execute("SET TRACE OFF", ())
+    except Exception as exc:
+        cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
+    try:
+        db.connect().rollback()
+    except Exception as exc:
+        cleanup_errors.append(f"rollback failed: {exc}")
+    if cleanup_errors:
+        logger.debug("explain_query cleanup: %s", "; ".join(cleanup_errors))
 
 
 @mcp.tool
 def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any]]:
     """Return ``COUNT(*)`` for each table (all user tables by default)."""
-    targets = table_names if table_names else all_table_names()
+    known = set(all_table_names())
+    targets = table_names if table_names else sorted(known)
     results: list[dict[str, Any]] = []
     for name in targets:
+        if name not in known:
+            results.append({"table": name, "row_count": None, "error": "unknown table"})
+            continue
         try:
-            rows = _db().fetch_all(f'SELECT COUNT(*) FROM "{name}"')
+            rows = _db().fetch_all("SELECT COUNT(*) FROM " + _quote_ident(name))
             results.append({"table": name, "row_count": int(rows[0][0]) if rows else 0})
         except Exception as exc:
             results.append({"table": name, "row_count": None, "error": str(exc)})
     return results
+
+
+def _quote_ident(name: str) -> str:
+    """Escape and double-quote a SQL identifier (ANSI style)."""
+    return '"' + name.replace('"', '""') + '"'
 
 
 @mcp.tool

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -79,6 +79,152 @@ def schema_definitions(table_name: str) -> list[dict[str, Any]]:
 
 
 @mcp.tool
+def describe_table(table_name: str) -> dict[str, Any]:
+    """Return full metadata for ``table_name``: columns, primary key, and indexes."""
+    columns = schema_definitions(table_name)
+    indexes = list_indexes(table_name)
+    primary_key = [col["name"] for col in columns if col["primary_key"]]
+    return {
+        "table": table_name,
+        "columns": columns,
+        "primary_key": primary_key,
+        "indexes": indexes,
+    }
+
+
+@mcp.tool
+def list_indexes(table_name: str) -> list[dict[str, Any]]:
+    """Return indexes for ``table_name`` with their key columns and flags."""
+    rows = _db().fetch_all(
+        """
+        SELECT i.index_name, i.is_unique, i.is_primary_key, i.is_foreign_key,
+               i.is_reverse, i.key_count, k.key_attr_name, k.key_order, k.asc_desc
+        FROM db_index i, db_index_key k
+        WHERE i.class_name = ?
+          AND i.index_name = k.index_name
+          AND i.class_name = k.class_name
+        ORDER BY i.index_name, k.key_order
+        """,
+        (table_name,),
+    )
+    indexes: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        name = r[0]
+        entry = indexes.setdefault(
+            name,
+            {
+                "name": name,
+                "unique": r[1] == "YES",
+                "primary_key": r[2] == "YES",
+                "foreign_key": r[3] == "YES",
+                "reverse": r[4] == "YES",
+                "key_count": r[5],
+                "columns": [],
+            },
+        )
+        entry["columns"].append({"name": r[6], "order": r[7], "asc_desc": r[8]})
+    return list(indexes.values())
+
+
+@mcp.tool
+def explain_query(sql: str) -> dict[str, Any]:
+    """Return CUBRID's execution plan/trace for a ``SELECT`` or ``WITH`` statement."""
+    cleaned = sql.strip().rstrip(";").strip()
+    if not cleaned:
+        raise ValueError("empty SQL statement")
+    leading = cleaned.split(None, 1)[0].upper()
+    if leading not in {"SELECT", "WITH"}:
+        raise ValueError("explain_query only accepts SELECT or WITH statements")
+
+    db = _db()
+    plan = ""
+    try:
+        with db.cursor() as cur:
+            cur.execute("SET TRACE ON", ())
+            cur.execute(cleaned, ())
+            cur.fetchall()
+            cur.execute("SHOW TRACE", ())
+            trace_rows = cur.fetchall()
+            if trace_rows and trace_rows[0]:
+                plan = str(trace_rows[0][0] or "").strip()
+    finally:
+        try:
+            with db.cursor() as cur:
+                cur.execute("SET TRACE OFF", ())
+        except Exception:
+            pass
+        try:
+            db.connect().rollback()
+        except Exception:
+            pass
+
+    return {"sql": cleaned, "plan": plan}
+
+
+@mcp.tool
+def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return ``COUNT(*)`` for each table (all user tables by default)."""
+    targets = table_names if table_names else all_table_names()
+    results: list[dict[str, Any]] = []
+    for name in targets:
+        try:
+            rows = _db().fetch_all(f'SELECT COUNT(*) FROM "{name}"')
+            results.append({"table": name, "row_count": int(rows[0][0]) if rows else 0})
+        except Exception as exc:
+            results.append({"table": name, "row_count": None, "error": str(exc)})
+    return results
+
+
+@mcp.tool
+def list_serials() -> list[dict[str, Any]]:
+    """Return CUBRID SERIAL sequences with current value, increment, and bounds."""
+    rows = _db().fetch_all(
+        """
+        SELECT name, current_val, increment_val, max_val, min_val,
+               cyclic, started, class_name, att_name, cached_num, comment
+        FROM db_serial
+        ORDER BY name
+        """
+    )
+    return [
+        {
+            "name": r[0],
+            "current_value": _coerce(r[1]),
+            "increment": _coerce(r[2]),
+            "max_value": _coerce(r[3]),
+            "min_value": _coerce(r[4]),
+            "cyclic": r[5] == 1 or r[5] == "1",
+            "started": r[6] == 1 or r[6] == "1",
+            "class_name": r[7],
+            "attribute_name": r[8],
+            "cached_num": r[9],
+            "comment": r[10],
+        }
+        for r in rows
+    ]
+
+
+@mcp.tool
+def list_class_hierarchy(table_name: str | None = None) -> list[dict[str, Any]]:
+    """Return CUBRID CLASS inheritance relationships (all classes or one class)."""
+    if table_name:
+        rows = _db().fetch_all(
+            "SELECT class_name, super_class_name FROM db_direct_super_class "
+            "WHERE class_name = ? ORDER BY super_class_name",
+            (table_name,),
+        )
+    else:
+        rows = _db().fetch_all(
+            "SELECT class_name, super_class_name FROM db_direct_super_class "
+            "ORDER BY class_name, super_class_name"
+        )
+    hierarchy: dict[str, list[str]] = {}
+    for child, parent in rows:
+        hierarchy.setdefault(child, []).append(parent)
+    return [{"class_name": k, "super_classes": v} for k, v in hierarchy.items()]
+
+
+@mcp.tool
 def execute_query(sql: str) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
     config = _config or Config.from_env()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubrid-mcp-server"
-version = "0.0.1"
+version = "0.1.0"
 description = "Model Context Protocol server for CUBRID database"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dev = [
     "pytest-cov",
     "ruff==0.15.8",
     "mypy==1.19.1",
-    "bandit[toml]==1.9.4",
     "pre-commit",
     "tox",
 ]
@@ -76,13 +75,6 @@ follow_untyped_imports = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 ignore_errors = true
-
-[tool.bandit]
-exclude_dirs = ["tests"]
-# B101: assert (used in tests via pytest)
-# B608: hardcoded_sql_expressions — false positive; identifiers are
-# whitelisted against db_class and escaped via _quote_ident (ANSI quoting)
-skips = ["B101", "B608"]
 
 [tool.coverage.run]
 source = ["cubrid_mcp_server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,10 @@ ignore_errors = true
 
 [tool.bandit]
 exclude_dirs = ["tests"]
-skips = ["B101"]
+# B101: assert (used in tests via pytest)
+# B608: hardcoded_sql_expressions — false positive; identifiers are
+# whitelisted against db_class and escaped via _quote_ident (ANSI quoting)
+skips = ["B101", "B608"]
 
 [tool.coverage.run]
 source = ["cubrid_mcp_server"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,6 +70,66 @@ class TestCubridIntegration:
         rows = self.db.fetch_all("SELECT 1 + 1")
         assert rows[0][0] == 2
 
+    def test_list_indexes_query(self) -> None:
+        rows = self.db.fetch_all(
+            "SELECT class_name FROM db_class WHERE is_system_class='NO' LIMIT 1"
+        )
+        if not rows:
+            pytest.skip("no user tables")
+        table = rows[0][0]
+        result = self.db.fetch_all(
+            "SELECT i.index_name, i.is_unique, i.is_primary_key, i.is_foreign_key, "
+            "i.is_reverse, i.key_count, k.key_attr_name, k.key_order, k.asc_desc "
+            "FROM db_index i, db_index_key k "
+            "WHERE i.class_name = ? AND i.index_name = k.index_name "
+            "AND i.class_name = k.class_name "
+            "ORDER BY i.index_name, k.key_order",
+            (table,),
+        )
+        assert isinstance(result, list)
+
+    def test_list_serials_query(self) -> None:
+        rows = self.db.fetch_all(
+            "SELECT name, current_val, increment_val, max_val, min_val, "
+            "cyclic, started, class_name, att_name, cached_num, comment "
+            "FROM db_serial ORDER BY name"
+        )
+        assert isinstance(rows, list)
+
+    def test_list_class_hierarchy_query(self) -> None:
+        rows = self.db.fetch_all(
+            "SELECT class_name, super_class_name FROM db_direct_super_class "
+            "ORDER BY class_name LIMIT 5"
+        )
+        assert isinstance(rows, list)
+
+    def test_v01_tools_via_server(self) -> None:
+        from cubrid_mcp_server import server
+
+        server._database = self.db
+        server._config = self.config
+        try:
+            tables = server.all_table_names()
+            assert isinstance(tables, list)
+            if tables:
+                desc = server.describe_table(tables[0])
+                assert desc["table"] == tables[0]
+                assert "columns" in desc and "indexes" in desc
+                idx = server.list_indexes(tables[0])
+                assert isinstance(idx, list)
+                counts = server.table_row_counts([tables[0]])
+                assert counts[0]["table"] == tables[0]
+            explain = server.explain_query("SELECT COUNT(*) FROM db_class")
+            assert "plan" in explain
+            assert "SELECT" in explain["plan"] or explain["plan"] == ""
+            serials = server.list_serials()
+            assert isinstance(serials, list)
+            hierarchy = server.list_class_hierarchy()
+            assert isinstance(hierarchy, list)
+        finally:
+            server._database = None
+            server._config = None
+
     def test_safety_blocks_write(self) -> None:
         from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,257 @@
+"""Unit tests for cubrid_mcp_server.server tools with a mocked Database."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cubrid_mcp_server import server
+from cubrid_mcp_server.config import Config
+
+_TEST_CONFIG = Config(
+    host="h", port=33000, user="u", password="", database="d",
+    readonly=True, max_chars=4000,
+)
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.responses: list[list[tuple[Any, ...]]] = []
+
+    def queue(self, rows: list[tuple[Any, ...]]) -> None:
+        self.responses.append(rows)
+
+    def fetch_all(
+        self, sql: str, params: tuple[Any, ...] | None = None
+    ) -> list[tuple[Any, ...]]:
+        self.calls.append((sql, params or ()))
+        if not self.responses:
+            return []
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def fake_db(monkeypatch: pytest.MonkeyPatch) -> FakeDatabase:
+    fake = FakeDatabase()
+    monkeypatch.setattr(server, "_db", lambda: fake)
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    return fake
+
+
+def test_all_table_names(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",), ("orders",)])
+    assert server.all_table_names() == ["users", "orders"]
+
+
+def test_filter_table_names(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",), ("orders",), ("user_roles",)])
+    assert server.filter_table_names("user") == ["users", "user_roles"]
+
+
+def test_filter_table_names_empty(fake_db: FakeDatabase) -> None:
+    assert server.filter_table_names("   ") == []
+
+
+def test_schema_definitions(fake_db: FakeDatabase) -> None:
+    fake_db.queue(
+        [
+            ("id", "INTEGER", "NO", None),
+            ("name", "VARCHAR", "YES", "''"),
+        ]
+    )
+    fake_db.queue([("id",)])
+    result = server.schema_definitions("users")
+    assert result == [
+        {
+            "name": "id",
+            "type": "INTEGER",
+            "nullable": False,
+            "default": None,
+            "primary_key": True,
+        },
+        {
+            "name": "name",
+            "type": "VARCHAR",
+            "nullable": True,
+            "default": "''",
+            "primary_key": False,
+        },
+    ]
+
+
+def test_list_indexes_groups_columns(fake_db: FakeDatabase) -> None:
+    fake_db.queue(
+        [
+            ("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC"),
+            ("idx_name", "NO", "NO", "NO", "NO", 2, "last", 0, "ASC"),
+            ("idx_name", "NO", "NO", "NO", "NO", 2, "first", 1, "ASC"),
+        ]
+    )
+    result = server.list_indexes("users")
+    assert result[0]["name"] == "pk_users"
+    assert result[0]["primary_key"] is True
+    assert result[0]["columns"] == [{"name": "id", "order": 0, "asc_desc": "ASC"}]
+    assert result[1]["name"] == "idx_name"
+    assert len(result[1]["columns"]) == 2
+
+
+def test_describe_table(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("id", "INTEGER", "NO", None)])
+    fake_db.queue([("id",)])
+    fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
+    result = server.describe_table("users")
+    assert result["table"] == "users"
+    assert result["primary_key"] == ["id"]
+    assert len(result["columns"]) == 1
+    assert len(result["indexes"]) == 1
+
+
+class FakeCursor:
+    def __init__(self, parent: "FakeConnDatabase") -> None:
+        self.parent = parent
+        self.executed: list[str] = []
+        self._fetch: list[tuple[Any, ...]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append(sql)
+        upper = sql.strip().upper()
+        if upper.startswith("SET TRACE") or upper == "":
+            self._fetch = []
+        elif upper.startswith("SHOW TRACE"):
+            self._fetch = [("\nTrace Statistics:\n  SELECT (time: 1)\n",)]
+        else:
+            self._fetch = [(1,)]
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._fetch
+
+
+class FakeConnDatabase(FakeDatabase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cursors: list[FakeCursor] = []
+        self.rolled_back = False
+
+    def cursor(self) -> Any:
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm() -> Any:
+            cur = FakeCursor(self)
+            self.cursors.append(cur)
+            try:
+                yield cur
+            finally:
+                pass
+
+        return _cm()
+
+    def connect(self) -> Any:
+        outer = self
+
+        class _Conn:
+            def rollback(self_inner) -> None:
+                outer.rolled_back = True
+
+        return _Conn()
+
+
+def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeConnDatabase()
+    monkeypatch.setattr(server, "_db", lambda: fake)
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    result = server.explain_query("SELECT 1")
+    assert result["sql"] == "SELECT 1"
+    assert "Trace Statistics" in result["plan"]
+    executed = [s for cur in fake.cursors for s in cur.executed]
+    assert any("SET TRACE ON" in s for s in executed)
+    assert any("SHOW TRACE" in s for s in executed)
+    assert any("SET TRACE OFF" in s for s in executed)
+    assert fake.rolled_back is True
+
+
+def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    with pytest.raises(ValueError):
+        server.explain_query("DROP TABLE users")
+
+
+def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    with pytest.raises(ValueError):
+        server.explain_query("   ")
+
+
+def test_table_row_counts_explicit(fake_db: FakeDatabase) -> None:
+    fake_db.queue([(42,)])
+    fake_db.queue([(7,)])
+    result = server.table_row_counts(["users", "orders"])
+    assert result == [
+        {"table": "users", "row_count": 42},
+        {"table": "orders", "row_count": 7},
+    ]
+
+
+def test_table_row_counts_defaults_to_all(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])
+    fake_db.queue([(3,)])
+    result = server.table_row_counts()
+    assert result == [{"table": "users", "row_count": 3}]
+
+
+def test_list_serials(fake_db: FakeDatabase) -> None:
+    fake_db.queue(
+        [
+            (
+                "order_seq",
+                100,
+                1,
+                9999999,
+                1,
+                0,
+                1,
+                "orders",
+                "id",
+                10,
+                "order pk",
+            )
+        ]
+    )
+    result = server.list_serials()
+    assert result[0]["name"] == "order_seq"
+    assert result[0]["current_value"] == 100
+    assert result[0]["started"] is True
+    assert result[0]["cyclic"] is False
+
+
+def test_list_class_hierarchy_all(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("child", "parent"), ("child", "mixin"), ("grand", "child")])
+    result = server.list_class_hierarchy()
+    assert {r["class_name"] for r in result} == {"child", "grand"}
+    child = next(r for r in result if r["class_name"] == "child")
+    assert set(child["super_classes"]) == {"parent", "mixin"}
+
+
+def test_list_class_hierarchy_single(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users", "base")])
+    result = server.list_class_hierarchy("users")
+    assert result == [{"class_name": "users", "super_classes": ["base"]}]
+    assert fake_db.calls[0][1] == ("users",)
+
+
+def test_execute_query_renders_and_truncates(
+    fake_db: FakeDatabase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = Config(
+        host="h", port=33000, user="u", password="", database="d",
+        readonly=True, max_chars=10,
+    )
+    monkeypatch.setattr(server, "_config", cfg)
+    fake_db.queue([("short",), ("a-much-longer-row",)])
+    result = server.execute_query("SELECT 1")
+    assert result["row_count"] == 2
+    assert result["truncated"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,8 +10,13 @@ from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
 
 _TEST_CONFIG = Config(
-    host="h", port=33000, user="u", password="", database="d",
-    readonly=True, max_chars=4000,
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
 )
 
 
@@ -23,9 +28,7 @@ class FakeDatabase:
     def queue(self, rows: list[tuple[Any, ...]]) -> None:
         self.responses.append(rows)
 
-    def fetch_all(
-        self, sql: str, params: tuple[Any, ...] | None = None
-    ) -> list[tuple[Any, ...]]:
+    def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         self.calls.append((sql, params or ()))
         if not self.responses:
             return []
@@ -247,8 +250,13 @@ def test_execute_query_renders_and_truncates(
     fake_db: FakeDatabase, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cfg = Config(
-        host="h", port=33000, user="u", password="", database="d",
-        readonly=True, max_chars=10,
+        host="h",
+        port=33000,
+        user="u",
+        password="",
+        database="d",
+        readonly=True,
+        max_chars=10,
     )
     monkeypatch.setattr(server, "_config", cfg)
     fake_db.queue([("short",), ("a-much-longer-row",)])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -190,6 +190,7 @@ def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_table_row_counts_explicit(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",), ("orders",)])
     fake_db.queue([(42,)])
     fake_db.queue([(7,)])
     result = server.table_row_counts(["users", "orders"])
@@ -197,6 +198,12 @@ def test_table_row_counts_explicit(fake_db: FakeDatabase) -> None:
         {"table": "users", "row_count": 42},
         {"table": "orders", "row_count": 7},
     ]
+
+
+def test_table_row_counts_rejects_unknown_table(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])
+    result = server.table_row_counts(["evil; DROP TABLE x"])
+    assert result == [{"table": "evil; DROP TABLE x", "row_count": None, "error": "unknown table"}]
 
 
 def test_table_row_counts_defaults_to_all(fake_db: FakeDatabase) -> None:


### PR DESCRIPTION
## Summary
Adds six new MCP tools for richer CUBRID introspection, bringing the server to **v0.1.0**.

| Tool | Description |
|------|-------------|
| `describe_table` | Columns + primary key + indexes in one call |
| `list_indexes` | Index metadata with key columns and flags |
| `explain_query` | Execution plan via CUBRID `SET TRACE ON` / `SHOW TRACE` |
| `table_row_counts` | `COUNT(*)` for one or many tables |
| `list_serials` | CUBRID `SERIAL` sequences (CUBRID-specific) |
| `list_class_hierarchy` | `CLASS` inheritance via `db_direct_super_class` |

### `explain_query` notes
CUBRID does not support the `EXPLAIN <SELECT>` keyword. Instead this tool runs `SET TRACE ON` → user query → `SHOW TRACE` → `SET TRACE OFF` + rollback inside a single transaction (pycubrid defaults to `autocommit=False`, so trace state survives across `cursor.execute` calls). Verified on CUBRID 11.2 with a real `Trace Statistics` payload.

### CI / publish workflow
Removes `environment: pypi` from `.github/workflows/publish.yml` so OIDC trusted publishing works without a pre-created GitHub environment. Configure the matching PyPI Trusted Publisher with the environment field left blank.

## Test plan
- [x] Unit tests with mocked `Database` (`tests/test_server.py`, 15 cases)
- [x] Integration tests against real CUBRID 11.2 (`tests/test_integration.py`, +5 cases for the new tools incl. an end-to-end sweep through the server functions)
- [x] `ruff check .`
- [x] `mypy cubrid_mcp_server`
- [x] Full suite: **57 passed** locally (`CUBRID_HOST=localhost ... pytest`)