### PR TITLE
chore: bump pycubrid floor to 1.4 for upstream bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.0",
-    "pycubrid>=1.0",
+    "pycubrid>=1.4,<2",
     "sqlparse>=0.5",
 ]
 


### PR DESCRIPTION
## Summary
- Raises minimum `pycubrid` from `>=1.0` to `>=1.4,<2`
- Forces consumers off old 1.0–1.3.x line that has known upstream bugs
- Adds an upper bound below 2.x as a SemVer guardrail

## Why
`pycubrid` 1.4.0 was released 2026-05-13 with upstream bug fixes since 1.0.0 (six releases: 1.1, 1.2, 1.3, 1.3.1, 1.3.2, 1.4). The current floor (`>=1.0`) allows users to resolve to a known-buggy version.

## Test plan
- [x] `pytest -m "not integration"` — 48 passed, 10 deselected (with pycubrid 1.4.0 installed)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 11 files already formatted
- [x] `mypy cubrid_mcp_server` — Success, no issues in 6 source files