### PR TITLE
fix: explain_query rejects multi-statement bypass

### DIFF
--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -138,6 +138,8 @@ def explain_query(sql: str) -> dict[str, Any]:
     leading = cleaned.split(None, 1)[0].upper()
     if leading not in {"SELECT", "WITH"}:
         raise ValueError("explain_query only accepts SELECT or WITH statements")
+    # Defense in depth: reject embedded second statements (e.g. "SELECT 1; DROP TABLE x").
+    ensure_read_only(cleaned)
 
     db = _db()
     plan = ""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ import pytest
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.safety import UnsafeSQLError
 
 _TEST_CONFIG = Config(
     host="h",
@@ -180,6 +181,13 @@ def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(server, "_config", _TEST_CONFIG)
     with pytest.raises(ValueError):
         server.explain_query("DROP TABLE users")
+
+
+def test_explain_query_rejects_multistatement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    with pytest.raises((ValueError, UnsafeSQLError)):
+        server.explain_query("SELECT 1; DROP TABLE users")
 
 
 def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
`explain_query` only inspected the first whitespace-split token of the cleaned SQL when enforcing its SELECT/WITH gate. Input like `SELECT 1; DROP TABLE users` passed that gate and was handed to `cur.execute(cleaned, ())` as-is.

Whether the driver actually runs a trailing statement is implementation-dependent, but a read-only EXPLAIN entry point should not rely on driver behavior.

## Fix
Call `ensure_read_only(cleaned)` after the SELECT/WITH gate. The safety checker already rejects multi-statement input, so the bypass is closed without changing legitimate single-statement explain behavior.

## Diff
- `cubrid_mcp_server/server.py` — 2 lines added (one comment, one call)
- `tests/test_server.py` — 1 regression test (`test_explain_query_rejects_multistatement`)

## Test plan
- [x] `pytest -m "not integration"` — 49 passed, 10 deselected
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 11 files already formatted
- [x] `mypy cubrid_mcp_server` — Success, no issues in 6 source files