### PR TITLE
fix: _render_rows always returns at least one row when truncated

### DIFF
--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -266,7 +266,9 @@ def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:
     for row in rows:
         serialized = [_coerce(value) for value in row]
         used += sum(len(str(value)) for value in serialized)
-        if used > max_chars:
+        # Always include at least one row, even when it alone exceeds max_chars,
+        # so callers see *something* instead of an empty truncated result.
+        if used > max_chars and output:
             return {"rows": output, "truncated": True}
         output.append(serialized)
     return {"rows": output, "truncated": False}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -270,3 +270,10 @@ def test_execute_query_renders_and_truncates(
     result = server.execute_query("SELECT 1")
     assert result["row_count"] == 2
     assert result["truncated"] is True
+
+
+def test_render_rows_returns_first_row_when_oversized() -> None:
+    rows = [("a-very-long-first-row",), ("short",)]
+    out = server._render_rows(rows, max_chars=5)
+    assert out["truncated"] is True
+    assert out["rows"] == [["a-very-long-first-row"]]


### PR DESCRIPTION
## Summary
When the first row's serialized length already exceeded `max_chars`, `_render_rows` returned `{"rows": [], "truncated": True}` — the caller saw no data at all, even though there was a matching row.

## Fix
Skip the early-return while `output` is still empty, so the first row is always emitted. Subsequent rows that push past the limit are dropped as before. One-character change in the guard plus a comment.

## Behavior
| input | max_chars | before | after |
|-------|----------:|--------|-------|
| `[("aaaa",), ("bbbb",)]` | 5 | `rows=[["aaaa"]] truncated=True` | unchanged |
| `[("a-very-long-row",), ("short",)]` | 5 | `rows=[] truncated=True` | `rows=[["a-very-long-row"]] truncated=True` |
| `[]` | any | `rows=[] truncated=False` | unchanged |

## Diff
- `cubrid_mcp_server/server.py` — 3 lines (1 logic change + 2-line comment)
- `tests/test_server.py` — 1 regression test (`test_render_rows_returns_first_row_when_oversized`)

## Test plan
- [x] `pytest -m "not integration"` — 49 passed, 10 deselected
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 11 files already formatted
- [x] `mypy cubrid_mcp_server` — Success, no issues in 6 source files