### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-05-15
+
+### Security
+- `explain_query` now rejects multi-statement input as defense in depth, closing a bypass where input like `SELECT 1; DROP TABLE users` cleared the SELECT/WITH gate. (#29)
+
+### Changed
+- Raised `pycubrid` minimum from `>=1.0` to `>=1.4,<2` to pull in upstream bug fixes from the 1.x line. Setups pinned to older `pycubrid` releases will need to upgrade. (#28)
+- `_render_rows` now always emits at least one row when truncating; previously a single oversized first row produced an empty `rows` list with `truncated: true`. (#30)
+- `cubrid_mcp_server.__version__` is now in sync with `pyproject.toml` (was stuck at `0.0.1`).
+
+### Added
+- Edge-case test coverage across `safety`, `_render_rows`, `_coerce`, `explain_query` keyword acceptance, and `_quote_ident` escaping. (#31)
+
+## [0.1.0] - 2026-04-13
+
+Initial release. Six MCP tools for read-only CUBRID inspection: `all_table_names`, `filter_table_names`, `schema_definitions`, `describe_table`, `list_indexes`, `execute_query`.

--- a/cubrid_mcp_server/__init__.py
+++ b/cubrid_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Model Context Protocol server for CUBRID database."""
 
-__version__ = "0.0.1"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubrid-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "Model Context Protocol server for CUBRID database"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Cuts v0.2.0. Bumps the package version, syncs `cubrid_mcp_server.__version__` with `pyproject.toml`, and introduces `CHANGELOG.md`.

## Merge order
This PR should land **after** #29, #30, and #31 so a single `v0.2.0` tag captures the full set of fixes and tests. The CHANGELOG already references those PR numbers.

## Why a minor (not patch)?
Pre-1.0, but two changes are observable to users:
- `pycubrid` floor moved from `>=1.0` to `>=1.4,<2` (#28, already merged) — environments pinned to older `pycubrid` need to upgrade.
- `_render_rows` now returns at least one row when truncating (#30) — callers who relied on the old empty-list behavior would see a different shape.

The `explain_query` security fix (#29) on its own would be a patch, but bundling these into a minor release is the more honest signal.

## Diff
- `pyproject.toml` — `version = "0.1.0"` → `"0.2.0"`
- `cubrid_mcp_server/__init__.py` — `__version__ = "0.0.1"` → `"0.2.0"` (corrects pre-existing drift)
- `CHANGELOG.md` — new file (Keep a Changelog format), v0.2.0 + retroactive v0.1.0 entry

## Post-merge
1. Tag `v0.2.0` on the merge commit
2. Create a GitHub Release (the existing `publish.yml` will pick it up and publish to PyPI via OIDC trust)

## Test plan
- [x] `pytest -m "not integration"` — 48 passed, 10 deselected
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 11 files already formatted
- [x] `mypy cubrid_mcp_server` — Success, no issues in 6 source files
- [x] `python -c "import cubrid_mcp_server; print(cubrid_mcp_server.__version__)"` → `0.2.0`