### PR TITLE
fix: tracker remediation (v0.2.1 + v0.2.2) — safety, connections, packaging, CI, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,27 @@ jobs:
         run: mypy cubrid_mcp_server
 
       - name: Pytest (unit)
+        run: pytest -m "not integration" --cov=cubrid_mcp_server --cov-report=term-missing
+
+  lowest-direct:
+    # Verify the project works against the lowest versions of its direct
+    # dependencies allowed by the version specifiers in pyproject.toml.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install with lowest-direct resolution
+        run: uv pip install --system --resolution lowest-direct -e ".[dev]"
+
+      - name: Pytest (unit)
         run: pytest -m "not integration"
 
   integration:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,25 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: python -m pip install --upgrade pip build
+        run: python -m pip install --upgrade pip build twine
 
       - name: Build package
         run: python -m build
 
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import cubrid_mcp_server; print(cubrid_mcp_server.__version__)")
+          echo "Release tag: $TAG | package version: $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag ($TAG) does not match package version ($PKG)"
+            exit 1
+          fi
+
+      - name: Check distribution metadata
+        run: twine check dist/*
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Read-only checker now scans the full token stream and rejects statements that begin with an allowed keyword but embed a forbidden one, e.g. a CTE `WITH ... DELETE` or a `SELECT ... FOR UPDATE`. (#40)
+- `main()` fails fast with a clear stderr message when configuration is missing or invalid, instead of surfacing the error on the first tool call. (#46)
+
+### Changed
+- `execute_query` now caps results at `CUBRID_MCP_MAX_ROWS` (default 1000, streamed via `fetchmany`) and truncates oversized *individual values* rather than dropping whole rows; `row_count` reflects the number of rows actually returned. (#37, #38)
+- Pinned `fastmcp>=3.0,<4`; the 2.x decorator typing behaviour is no longer supported. (#35)
+- Schema/describe/index/row-count tools resolve the requested table against the catalog first and raise a clear error for unknown tables (excluding system classes and views). (#42, #43, #47)
+- `explain_query` holds the connection lock across the whole `SET TRACE ... SHOW TRACE` sequence and no longer drains the user query result set. (#44)
+- `table_row_counts` is capped at 50 tables per call. (#45)
+- Binary column values are base64-encoded when small and summarized as `<binary N bytes>` when large. (#48)
+- `Config.password` is excluded from `repr()`, and connection errors no longer echo the password or raw driver message. (#34, #41)
+- The database wrapper closes stale connections before discarding them and serializes cursor access behind a re-entrant lock. (#33, #39)
+- All logging is directed to stderr so it cannot corrupt the stdio MCP protocol stream on stdout. (#57)
+
+### Added
+- `py.typed` marker so downstream users get type information; package version is now derived dynamically from `cubrid_mcp_server.__version__`. (#54, #55)
+- CI reports coverage and runs a lowest-direct dependency-resolution job; the publish workflow verifies the tag matches the package version, runs `twine check`, and emits attestations. (#50, #51, #56)
+
+### Fixed
+- Corrected the repository org in project URLs and docs (`cubrid-labs` → `cubrid-lab`). (#53)
+
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [0.2.0] - 2026-05-15
 
 ### Security
@@ -14,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raised `pycubrid` minimum from `>=1.0` to `>=1.4,<2` to pull in upstream bug fixes from the 1.x line. Setups pinned to older `pycubrid` releases will need to upgrade. (#28)
 - `_render_rows` now always emits at least one row when truncating; previously a single oversized first row produced an empty `rows` list with `truncated: true`. (#30)
 - `cubrid_mcp_server.__version__` is now in sync with `pyproject.toml` (was stuck at `0.0.1`).
+  Note: this sync landed in the 0.2.0 source but the originally published 0.2.0 metadata may still reflect the old value; from `0.2.1` onward the version is derived dynamically to prevent drift. (#58)
 
 ### Added
 - Edge-case test coverage across `safety`, `_render_rows`, `_coerce`, `explain_query` keyword acceptance, and `_quote_ident` escaping. (#31)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ The server is **read-only by default**. A code-level SQL whitelist allows only `
 
 For production use, also configure a read-only database user. See [`SECURITY.md`](./SECURITY.md) for the recommended setup.
 
+## Logging
+
+The server speaks the MCP **stdio transport**, where `stdout` carries the JSON-RPC protocol stream. Anything written to `stdout` by the server or its dependencies will corrupt that stream and break the client connection. For this reason **all logging is routed to `stderr`**, and you should keep it that way: when adding custom logging or diagnostics, never `print()` to `stdout` — use the standard `logging` module (which is configured to emit on `stderr`) or write to `stderr` explicitly. The log level defaults to `INFO`.
+
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For production use, also configure a read-only database user. See [`SECURITY.md`
 ## Development
 
 ```bash
-git clone https://github.com/cubrid-labs/cubrid-mcp-server.git
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
 cd cubrid-mcp-server
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,21 @@ Optional settings:
 
 ### Run
 
-No installation required — use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to run directly from PyPI:
+> **Note:** The package is not yet published to PyPI. Until the first release lands, install and run it from source (see [Development](#development)); the `uvx`/`pipx` commands below will work once the package is available on PyPI.
+
+### Run from source (available now)
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cubrid-mcp-server
+```
+
+### Run from PyPI (once published)
+
+Use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to run directly from PyPI:
 
 ```bash
 uvx cubrid-mcp-server

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,11 @@ Minimum recommended setup for an exploration/analytics workload:
 -- 1. Create the user
 CREATE USER mcp_reader PASSWORD 'replace-me';
 
--- 2. Grant only read on the schemas you want exposed
-GRANT SELECT ON demodb.* TO mcp_reader;
+-- 2. Grant SELECT only on the specific tables you want exposed.
+--    CUBRID grants privileges per table (there is no schema-wide `db.*` grant).
+GRANT SELECT ON customers TO mcp_reader;
+GRANT SELECT ON orders TO mcp_reader;
+-- ...repeat for each table the model may read.
 
 -- 3. Do NOT grant CREATE, ALTER, DROP, INSERT, UPDATE, DELETE, GRANT, or any DBA role.
 ```
@@ -36,7 +39,7 @@ You can disable this layer by setting `CUBRID_MCP_READONLY=0`, but only do so wh
 
 ## Layer 3 — output limits
 
-`execute_query` truncates rendered output once the cumulative character count exceeds `CUBRID_MCP_MAX_CHARS` (default 4000). This protects the model's context window, and it also limits how much data a single probing query can exfiltrate in one shot.
+`execute_query` caps the number of rows returned at `CUBRID_MCP_MAX_ROWS` (default 1000) and truncates rendered output once the cumulative character count exceeds `CUBRID_MCP_MAX_CHARS` (default 4000). Together these protect the model's context window and limit how much data a single probing query can exfiltrate in one shot. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large, so raw blobs never flood the output.
 
 ## Reporting a vulnerability
 
@@ -50,4 +53,4 @@ You should receive an acknowledgement within three business days. Coordinated di
 
 ## Supported versions
 
-The project is in pre-alpha (`0.0.x`). Only the latest tagged release receives security fixes until the API stabilises.
+The project is in early development (`0.2.x`). Only the latest tagged release receives security fixes until the API stabilises.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,9 @@ You can disable this layer by setting `CUBRID_MCP_READONLY=0`, but only do so wh
 - the underlying DB user is already read-only (Layer 1 is in place), **and**
 - you genuinely need statements outside the whitelist (for example, CUBRID administrative `SHOW` variants that confuse the parser).
 
+**`explain_query` is always read-only**, independent of `CUBRID_MCP_READONLY`. It only ever produces a plan for a `SELECT`/`WITH` query, so it always applies the whitelist even when the server is nominally in write-allowed mode. Only `execute_query` honors `CUBRID_MCP_READONLY=0`.
+- you genuinely need statements outside the whitelist (for example, CUBRID administrative `SHOW` variants that confuse the parser).
+
 ## Layer 3 — output limits
 
 `execute_query` caps the number of rows returned at `CUBRID_MCP_MAX_ROWS` (default 1000) and truncates rendered output once the cumulative character count exceeds `CUBRID_MCP_MAX_CHARS` (default 4000). Together these protect the model's context window and limit how much data a single probing query can exfiltrate in one shot. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large, so raw blobs never flood the output.

--- a/cubrid_mcp_server/config.py
+++ b/cubrid_mcp_server/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 class ConfigError(RuntimeError):
@@ -15,10 +15,11 @@ class Config:
     host: str
     port: int
     user: str
-    password: str
+    password: str = field(repr=False)
     database: str
     readonly: bool
     max_chars: int
+    max_rows: int
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Config":
@@ -49,6 +50,16 @@ class Config:
         if max_chars <= 0:
             raise ConfigError("CUBRID_MCP_MAX_CHARS must be positive")
 
+        max_rows_raw = source.get("CUBRID_MCP_MAX_ROWS", "1000")
+        try:
+            max_rows = int(max_rows_raw)
+        except ValueError as exc:
+            raise ConfigError(
+                f"CUBRID_MCP_MAX_ROWS must be an integer, got {max_rows_raw!r}"
+            ) from exc
+        if max_rows <= 0:
+            raise ConfigError("CUBRID_MCP_MAX_ROWS must be positive")
+
         return cls(
             host=host,
             port=port,
@@ -57,6 +68,7 @@ class Config:
             database=database,
             readonly=readonly,
             max_chars=max_chars,
+            max_rows=max_rows,
         )
 
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+import threading
 from contextlib import contextmanager
 from typing import Any, Iterator
 
 import pycubrid
 
 from cubrid_mcp_server.config import Config
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseError(RuntimeError):
@@ -20,6 +24,7 @@ class Database:
     def __init__(self, config: Config) -> None:
         self._config = config
         self._connection: Any = None
+        self._lock = threading.RLock()
 
     def connect(self) -> Any:
         if self._connection is not None:
@@ -27,7 +32,7 @@ class Database:
                 self._connection.get_server_version()
                 return self._connection
             except Exception:
-                self._connection = None
+                self._discard_connection()
 
         try:
             self._connection = pycubrid.connect(
@@ -39,8 +44,21 @@ class Database:
                 connect_timeout=10,
             )
         except Exception as exc:  # pragma: no cover - driver-specific
-            raise DatabaseError(f"failed to connect to CUBRID: {exc}") from exc
+            raise DatabaseError(
+                f"failed to connect to CUBRID host={self._config.host} "
+                f"database={self._config.database}"
+            ) from exc
         return self._connection
+
+    def _discard_connection(self) -> None:
+        """Drop the cached connection, closing it first on a best-effort basis."""
+        connection = self._connection
+        self._connection = None
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception as exc:
+                logger.debug("failed to close stale connection: %s", exc)
 
     def close(self) -> None:
         if self._connection is not None:
@@ -51,16 +69,50 @@ class Database:
 
     @contextmanager
     def cursor(self) -> Iterator[Any]:
-        connection = self.connect()
-        cursor = connection.cursor()
-        try:
-            yield cursor
-        except Exception as exc:
-            raise DatabaseError(f"query failed: {exc}") from exc
-        finally:
-            cursor.close()
+        with self._lock:
+            connection = self.connect()
+            cursor = connection.cursor()
+            try:
+                yield cursor
+            except Exception as exc:
+                raise DatabaseError(f"query failed: {exc}") from exc
+            finally:
+                cursor.close()
+
+    @contextmanager
+    def exclusive(self) -> Iterator[Any]:
+        """Hold the connection lock across multiple statements (e.g. SET TRACE ... SHOW TRACE)."""
+        with self._lock:
+            yield self.connect()
 
     def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         with self.cursor() as cursor:
             cursor.execute(sql, params or ())
             return list(cursor.fetchall())
+
+    def fetch_many(
+        self,
+        sql: str,
+        params: tuple[Any, ...] | None = None,
+        max_rows: int | None = None,
+    ) -> tuple[list[tuple[Any, ...]], bool]:
+        """Stream rows, returning ``(rows, truncated)``.
+
+        At most ``max_rows`` rows are returned; ``truncated`` is ``True`` when the
+        result set contained more rows than that. When ``max_rows`` is ``None`` all
+        rows are returned and ``truncated`` is always ``False``.
+        """
+        with self.cursor() as cursor:
+            cursor.execute(sql, params or ())
+            rows: list[tuple[Any, ...]] = []
+            truncated = False
+            while True:
+                batch = cursor.fetchmany(100)
+                if not batch:
+                    break
+                for row in batch:
+                    if max_rows is not None and len(rows) >= max_rows:
+                        truncated = True
+                        return rows, truncated
+                    rows.append(row)
+            return rows, truncated

--- a/cubrid_mcp_server/safety.py
+++ b/cubrid_mcp_server/safety.py
@@ -12,12 +12,41 @@ configure CUBRID with a read-only user account for production use. See
 
 from __future__ import annotations
 
+from typing import Any
+
 import sqlparse
 from sqlparse.sql import Statement
 from sqlparse.tokens import Keyword
 
 READ_ONLY_KEYWORDS: frozenset[str] = frozenset(
     {"SELECT", "SHOW", "DESC", "DESCRIBE", "EXPLAIN", "WITH"}
+)
+
+# Keywords that mutate data/schema or otherwise escape read-only mode. Even when a
+# statement begins with an allowed keyword (e.g. a CTE ``WITH ... AS (...) DELETE`` or
+# a ``SELECT ... FOR UPDATE``), the presence of any of these anywhere in the token
+# stream is rejected as defence-in-depth.
+FORBIDDEN_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "REPLACE",
+        "MERGE",
+        "DROP",
+        "CREATE",
+        "ALTER",
+        "TRUNCATE",
+        "GRANT",
+        "REVOKE",
+        "RENAME",
+        "CALL",
+        "EXECUTE",
+        "COMMIT",
+        "ROLLBACK",
+        "LOCK",
+        "INTO",
+    }
 )
 
 
@@ -46,6 +75,10 @@ def ensure_read_only(sql: str) -> None:
             f"allowed statements: {', '.join(sorted(READ_ONLY_KEYWORDS))}"
         )
 
+    forbidden = _forbidden_keywords(statement)
+    if forbidden:
+        raise UnsafeSQLError(f"{sorted(forbidden)[0]} is not permitted in read-only mode")
+
 
 def _is_non_empty(statement: Statement) -> bool:
     stripped = statement.value.strip().rstrip(";").strip()
@@ -63,3 +96,20 @@ def _leading_keyword(statement: Statement) -> str | None:
             if inner is not None:
                 return inner
     return None
+
+
+def _forbidden_keywords(statement: Statement) -> set[str]:
+    """Return any forbidden keyword tokens found anywhere in ``statement``."""
+    found: set[str] = set()
+    _collect_forbidden(statement, found)
+    return found
+
+
+def _collect_forbidden(token: Any, found: set[str]) -> None:
+    for child in getattr(token, "tokens", []):
+        if child.ttype is not None and child.ttype in Keyword:
+            upper = str(child.value).upper()
+            if upper in FORBIDDEN_KEYWORDS:
+                found.add(upper)
+        if hasattr(child, "tokens"):
+            _collect_forbidden(child, found)

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
+import base64
 import logging
+import sys
 from typing import Any
 
 from fastmcp import FastMCP
 
-from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.config import Config, ConfigError
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
 
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("cubrid-mcp-server")
+
+# Cap on how many tables ``table_row_counts`` will scan in a single call, to avoid
+# accidentally issuing hundreds of COUNT(*) queries against a large database.
+_MAX_ROW_COUNT_TABLES = 50
+
+# Binary values up to this size are returned base64-encoded; larger blobs are summarized.
+_MAX_INLINE_BINARY_BYTES = 256
 
 _config: Config | None = None
 _database: Database | None = None
@@ -27,13 +36,36 @@ def _db() -> Database:
     return _database
 
 
+def _all_table_names() -> list[str]:
+    """Internal helper: list every user table (excludes system classes and views)."""
+    rows = _db().fetch_all(
+        "SELECT class_name FROM db_class "
+        "WHERE is_system_class='NO' AND class_type='CLASS' "
+        "ORDER BY class_name"
+    )
+    return [row[0] for row in rows]
+
+
+def _resolve_table(table_name: str) -> str:
+    """Resolve ``table_name`` to its canonical stored name (case-insensitive).
+
+    Raises :class:`ValueError` if no matching user table exists. This both prevents
+    lookups against system classes/views and gives callers a clear error instead of
+    silently returning empty metadata.
+    """
+    needle = table_name.strip().lower()
+    if not needle:
+        raise ValueError("table name must not be empty")
+    for name in _all_table_names():
+        if name.lower() == needle:
+            return name
+    raise ValueError(f"unknown table: {table_name!r}")
+
+
 @mcp.tool
 def all_table_names() -> list[str]:
     """Return every user table in the connected CUBRID database."""
-    rows = _db().fetch_all(
-        "SELECT class_name FROM db_class WHERE is_system_class='NO' ORDER BY class_name"
-    )
-    return [row[0] for row in rows]
+    return _all_table_names()
 
 
 @mcp.tool
@@ -42,12 +74,10 @@ def filter_table_names(substring: str) -> list[str]:
     needle = substring.strip().lower()
     if not needle:
         return []
-    return [name for name in all_table_names() if needle in name.lower()]
+    return [name for name in _all_table_names() if needle in name.lower()]
 
 
-@mcp.tool
-def schema_definitions(table_name: str) -> list[dict[str, Any]]:
-    """Return column metadata for ``table_name``: name, type, nullability, default, PK flag."""
+def _schema_definitions(table_name: str) -> list[dict[str, Any]]:
     rows = _db().fetch_all(
         """
         SELECT a.attr_name, a.data_type, a.is_nullable, a.default_value
@@ -82,22 +112,27 @@ def schema_definitions(table_name: str) -> list[dict[str, Any]]:
 
 
 @mcp.tool
+def schema_definitions(table_name: str) -> list[dict[str, Any]]:
+    """Return column metadata for ``table_name``: name, type, nullability, default, PK flag."""
+    return _schema_definitions(_resolve_table(table_name))
+
+
+@mcp.tool
 def describe_table(table_name: str) -> dict[str, Any]:
     """Return full metadata for ``table_name``: columns, primary key, and indexes."""
-    columns = schema_definitions(table_name)
-    indexes = list_indexes(table_name)
+    resolved = _resolve_table(table_name)
+    columns = _schema_definitions(resolved)
+    indexes = _list_indexes(resolved)
     primary_key = [col["name"] for col in columns if col["primary_key"]]
     return {
-        "table": table_name,
+        "table": resolved,
         "columns": columns,
         "primary_key": primary_key,
         "indexes": indexes,
     }
 
 
-@mcp.tool
-def list_indexes(table_name: str) -> list[dict[str, Any]]:
-    """Return indexes for ``table_name`` with their key columns and flags."""
+def _list_indexes(table_name: str) -> list[dict[str, Any]]:
     rows = _db().fetch_all(
         """
         SELECT i.index_name, i.is_unique, i.is_primary_key, i.is_foreign_key,
@@ -130,6 +165,12 @@ def list_indexes(table_name: str) -> list[dict[str, Any]]:
 
 
 @mcp.tool
+def list_indexes(table_name: str) -> list[dict[str, Any]]:
+    """Return indexes for ``table_name`` with their key columns and flags."""
+    return _list_indexes(_resolve_table(table_name))
+
+
+@mcp.tool
 def explain_query(sql: str) -> dict[str, Any]:
     """Return CUBRID's execution plan/trace for a ``SELECT`` or ``WITH`` statement."""
     cleaned = sql.strip().rstrip(";").strip()
@@ -143,31 +184,39 @@ def explain_query(sql: str) -> dict[str, Any]:
 
     db = _db()
     plan = ""
-    try:
-        with db.cursor() as cur:
-            cur.execute("SET TRACE ON", ())
-            cur.execute(cleaned, ())
-            cur.fetchall()
-            cur.execute("SHOW TRACE", ())
-            trace_rows = cur.fetchall()
-            if trace_rows and trace_rows[0]:
-                plan = str(trace_rows[0][0] or "").strip()
-    finally:
-        _reset_trace_state(db)
+    # Hold the connection lock across the whole SET TRACE ... SHOW TRACE sequence so a
+    # concurrent query cannot interleave and clobber the session trace state.
+    with db.exclusive() as connection:
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute("SET TRACE ON", ())
+                cursor.execute(cleaned, ())
+                cursor.execute("SHOW TRACE", ())
+                trace_rows = cursor.fetchall()
+                if trace_rows and trace_rows[0]:
+                    plan = str(trace_rows[0][0] or "").strip()
+            finally:
+                cursor.close()
+        finally:
+            _reset_trace_state(connection)
 
     return {"sql": cleaned, "plan": plan}
 
 
-def _reset_trace_state(db: Database) -> None:
+def _reset_trace_state(connection: Any) -> None:
     """Best-effort cleanup of ``SET TRACE`` session state and pending transaction."""
     cleanup_errors: list[str] = []
     try:
-        with db.cursor() as cur:
-            cur.execute("SET TRACE OFF", ())
+        cursor = connection.cursor()
+        try:
+            cursor.execute("SET TRACE OFF", ())
+        finally:
+            cursor.close()
     except Exception as exc:
         cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
     try:
-        db.connect().rollback()
+        connection.rollback()
     except Exception as exc:
         cleanup_errors.append(f"rollback failed: {exc}")
     if cleanup_errors:
@@ -176,19 +225,25 @@ def _reset_trace_state(db: Database) -> None:
 
 @mcp.tool
 def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any]]:
-    """Return ``COUNT(*)`` for each table (all user tables by default)."""
-    known = set(all_table_names())
+    """Return ``COUNT(*)`` for each table (all user tables by default, capped)."""
+    known = _all_table_names()
+    known_lower = {name.lower(): name for name in known}
     targets = table_names if table_names else sorted(known)
+    if len(targets) > _MAX_ROW_COUNT_TABLES:
+        raise ValueError(
+            f"too many tables requested ({len(targets)}); limit is {_MAX_ROW_COUNT_TABLES} per call"
+        )
     results: list[dict[str, Any]] = []
     for name in targets:
-        if name not in known:
+        resolved = known_lower.get(name.strip().lower())
+        if resolved is None:
             results.append({"table": name, "row_count": None, "error": "unknown table"})
             continue
         try:
-            rows = _db().fetch_all("SELECT COUNT(*) FROM " + _quote_ident(name))
-            results.append({"table": name, "row_count": int(rows[0][0]) if rows else 0})
+            rows = _db().fetch_all("SELECT COUNT(*) FROM " + _quote_ident(resolved))
+            results.append({"table": resolved, "row_count": int(rows[0][0]) if rows else 0})
         except Exception as exc:
-            results.append({"table": name, "row_count": None, "error": str(exc)})
+            results.append({"table": resolved, "row_count": None, "error": str(exc)})
     return results
 
 
@@ -249,15 +304,16 @@ def list_class_hierarchy(table_name: str | None = None) -> list[dict[str, Any]]:
 @mcp.tool
 def execute_query(sql: str) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
+    db = _db()
     config = _config or Config.from_env()
     if config.readonly:
         ensure_read_only(sql)
 
-    rows = _db().fetch_all(sql)
+    rows, row_truncated = db.fetch_many(sql, None, config.max_rows)
     rendered = _render_rows(rows, config.max_chars)
     return {
-        "row_count": len(rows),
-        "truncated": rendered["truncated"],
+        "row_count": len(rendered["rows"]),
+        "truncated": bool(rendered["truncated"] or row_truncated),
         "rows": rendered["rows"],
     }
 
@@ -265,22 +321,50 @@ def execute_query(sql: str) -> dict[str, Any]:
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:
     output: list[list[Any]] = []
     used = 0
+    truncated = False
     for row in rows:
-        serialized = [_coerce(value) for value in row]
+        serialized = [_truncate_value(_coerce(value), max_chars) for value in row]
         used += sum(len(str(value)) for value in serialized)
         # Always include at least one row, even when it alone exceeds max_chars,
         # so callers see *something* instead of an empty truncated result.
         if used > max_chars and output:
-            return {"rows": output, "truncated": True}
+            truncated = True
+            break
         output.append(serialized)
-    return {"rows": output, "truncated": False}
+    return {"rows": output, "truncated": truncated}
+
+
+def _truncate_value(value: Any, limit: int) -> Any:
+    """Truncate an individual string value that alone exceeds ``limit`` characters."""
+    if isinstance(value, str) and limit > 0 and len(value) > limit:
+        return value[: limit - 1] + "\u2026"
+    return value
 
 
 def _coerce(value: Any) -> Any:
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
+    if isinstance(value, (bytes, bytearray)):
+        data = bytes(value)
+        if len(data) <= _MAX_INLINE_BINARY_BYTES:
+            return base64.b64encode(data).decode("ascii")
+        return f"<binary {len(data)} bytes>"
     return str(value)
 
 
 def main() -> None:
+    # The MCP stdio transport uses stdout as the protocol channel, so ALL logging
+    # must go to stderr — a stray log line on stdout corrupts the JSON-RPC stream.
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    # Fail fast with a clear message if configuration is missing/invalid, rather than
+    # surfacing the error on the first tool call.
+    try:
+        Config.from_env()
+    except ConfigError as exc:
+        print(f"configuration error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
     mcp.run()

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -179,7 +179,11 @@ def explain_query(sql: str) -> dict[str, Any]:
     leading = cleaned.split(None, 1)[0].upper()
     if leading not in {"SELECT", "WITH"}:
         raise ValueError("explain_query only accepts SELECT or WITH statements")
-    # Defense in depth: reject embedded second statements (e.g. "SELECT 1; DROP TABLE x").
+    # explain_query is *intentionally* always read-only, regardless of
+    # ``config.readonly``: it can only ever produce a plan for a SELECT/WITH query,
+    # so there is no meaningful write-mode behavior to gate. This differs from
+    # execute_query, which honors CUBRID_MCP_READONLY. ensure_read_only also rejects
+    # embedded second statements (e.g. "SELECT 1; DROP TABLE x") as defense in depth.
     ensure_read_only(cleaned)
 
     db = _db()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubrid-mcp-server"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Model Context Protocol server for CUBRID database"
 readme = "README.md"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Database :: Front-Ends",
 ]
 dependencies = [
-    "fastmcp>=2.0",
+    "fastmcp>=3.0,<4",
     "pycubrid>=1.4,<2",
     "sqlparse>=0.5",
 ]
@@ -46,13 +46,19 @@ dev = [
 cubrid-mcp-server = "cubrid_mcp_server.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/cubrid-labs/cubrid-mcp-server"
-Repository = "https://github.com/cubrid-labs/cubrid-mcp-server"
-Issues = "https://github.com/cubrid-labs/cubrid-mcp-server/issues"
+Homepage = "https://github.com/cubrid-lab/cubrid-mcp-server"
+Repository = "https://github.com/cubrid-lab/cubrid-mcp-server"
+Issues = "https://github.com/cubrid-lab/cubrid-mcp-server/issues"
 
 [tool.setuptools]
 packages = ["cubrid_mcp_server"]
 include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "cubrid_mcp_server.__version__"}
+
+[tool.setuptools.package-data]
+cubrid_mcp_server = ["py.typed"]
 
 [tool.ruff]
 line-length = 100
@@ -85,7 +91,7 @@ fail_under = 95
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--tb native -v -r fxX --maxfail=25 -p no:warnings"
+addopts = "--tb native -v -r fxX -p no:warnings"
 python_files = "tests/*test_*.py"
 markers = [
     "integration: tests that require a running CUBRID instance",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ def test_from_env_defaults() -> None:
     assert cfg.database == "demodb"
     assert cfg.readonly is True
     assert cfg.max_chars == 4000
+    assert cfg.max_rows == 1000
 
 
 def test_from_env_overrides() -> None:
@@ -57,3 +58,20 @@ def test_from_env_invalid_max_chars() -> None:
 def test_from_env_invalid_readonly() -> None:
     with pytest.raises(ConfigError, match="boolean"):
         Config.from_env(BASE_ENV | {"CUBRID_MCP_READONLY": "maybe"})
+
+
+def test_from_env_max_rows_override() -> None:
+    cfg = Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_ROWS": "250"})
+    assert cfg.max_rows == 250
+
+
+def test_from_env_invalid_max_rows() -> None:
+    with pytest.raises(ConfigError, match="CUBRID_MCP_MAX_ROWS"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_ROWS": "lots"})
+    with pytest.raises(ConfigError, match="positive"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_ROWS": "0"})
+
+
+def test_password_not_in_repr() -> None:
+    cfg = Config.from_env(BASE_ENV)
+    assert "secret" not in repr(cfg)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,186 @@
+"""Coverage for error/edge branches in server and safety modules.
+
+These exercise the defensive paths (lazy init, cleanup-on-error, oversized
+binary summaries, startup config failure) that the happy-path tests skip.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import cubrid_mcp_server.server as server
+from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.safety import ensure_read_only
+
+_TEST_CONFIG = Config(
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
+
+
+# ---------------------------------------------------------------------------
+# _db() lazy initialization
+# ---------------------------------------------------------------------------
+
+
+def test_db_lazily_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_config", None)
+    monkeypatch.setattr(server, "_database", None)
+    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+
+    created: list[Any] = []
+
+    class _FakeDatabase:
+        def __init__(self, config: Config) -> None:
+            created.append(config)
+
+    monkeypatch.setattr(server, "Database", _FakeDatabase)
+
+    first = server._db()
+    second = server._db()
+    assert first is second
+    assert created == [_TEST_CONFIG]  # constructed exactly once
+
+
+# ---------------------------------------------------------------------------
+# _resolve_table error branches
+# ---------------------------------------------------------------------------
+
+
+class _NameOnlyDB:
+    """Minimal db exposing fetch_all for _all_table_names lookups."""
+
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
+        return [(n,) for n in self._names]
+
+
+def test_resolve_table_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    with pytest.raises(ValueError, match="must not be empty"):
+        server._resolve_table("   ")
+
+
+def test_resolve_table_rejects_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    with pytest.raises(ValueError, match="unknown table"):
+        server._resolve_table("ghost")
+
+
+# ---------------------------------------------------------------------------
+# _reset_trace_state error branches (explain_query cleanup)
+# ---------------------------------------------------------------------------
+
+
+class _FailingCursor:
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        if sql == "SET TRACE OFF":
+            raise RuntimeError("trace off boom")
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return [("plan text",)]
+
+    def close(self) -> None:
+        pass
+
+
+class _CleanupFailingConn:
+    def cursor(self) -> _FailingCursor:
+        return _FailingCursor()
+
+    def rollback(self) -> None:
+        raise RuntimeError("rollback boom")
+
+
+class _CleanupFailingDB:
+    @contextmanager
+    def exclusive(self) -> Any:
+        yield _CleanupFailingConn()
+
+
+def test_explain_query_swallows_cleanup_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SET TRACE OFF and rollback failures during cleanup are logged, not raised."""
+    monkeypatch.setattr(server, "_db", lambda: _CleanupFailingDB())
+    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    result = server.explain_query("SELECT 1")
+    assert result["plan"] == "plan text"
+    assert result["sql"] == "SELECT 1"
+
+
+# ---------------------------------------------------------------------------
+# table_row_counts limit + per-table error branches
+# ---------------------------------------------------------------------------
+
+
+class _RowCountErrorDB:
+    def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
+        if "db_class" in sql:
+            return [("users",)]
+        raise RuntimeError("count failed")
+
+
+def test_table_row_counts_rejects_too_many_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    too_many = [f"t{i}" for i in range(server._MAX_ROW_COUNT_TABLES + 1)]
+    with pytest.raises(ValueError, match="too many tables"):
+        server.table_row_counts(too_many)
+
+
+def test_table_row_counts_reports_per_table_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: _RowCountErrorDB())
+    result = server.table_row_counts(["users"])
+    assert result == [{"table": "users", "row_count": None, "error": "count failed"}]
+
+
+# ---------------------------------------------------------------------------
+# _coerce oversized binary summary
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_oversized_binary_returns_size_summary() -> None:
+    data = b"\x00" * (server._MAX_INLINE_BINARY_BYTES + 1)
+    assert server._coerce(data) == f"<binary {len(data)} bytes>"
+
+
+# ---------------------------------------------------------------------------
+# main() startup paths
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_on_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(cls: type[Config]) -> Config:
+        raise ConfigError("missing CUBRID_HOST")
+
+    monkeypatch.setattr(Config, "from_env", classmethod(_raise))
+    with pytest.raises(SystemExit) as excinfo:
+        server.main()
+    assert excinfo.value.code == 1
+
+
+def test_main_runs_server_on_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+    ran: list[bool] = []
+    monkeypatch.setattr(server.mcp, "run", lambda: ran.append(True))
+    server.main()
+    assert ran == [True]
+
+
+# ---------------------------------------------------------------------------
+# safety: leading keyword nested inside a parenthesized group
+# ---------------------------------------------------------------------------
+
+
+def test_safety_accepts_parenthesized_select() -> None:
+    # Leading token is a group; _leading_keyword must recurse into it.
+    ensure_read_only("(SELECT 1)")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,181 @@
+"""Unit tests for cubrid_mcp_server.database using a fake pycubrid driver.
+
+These exercise the connection lifecycle, cursor error handling, and streaming
+fetch logic without a live CUBRID server by monkeypatching ``pycubrid.connect``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import pycubrid
+from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.database import Database, DatabaseError
+
+_TEST_CONFIG = Config(
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
+
+
+class FakeCursor:
+    def __init__(self, rows: list[tuple[Any, ...]] | None = None) -> None:
+        self._rows = list(rows or [])
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.closed = False
+        self._fetch_offset = 0
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        self.executed.append((sql, params))
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._rows)
+
+    def fetchmany(self, size: int) -> list[tuple[Any, ...]]:
+        chunk = self._rows[self._fetch_offset : self._fetch_offset + size]
+        self._fetch_offset += size
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, rows: list[tuple[Any, ...]] | None = None) -> None:
+        self._rows = rows
+        self.closed = False
+        self.server_version_calls = 0
+        self.version_error = False
+        self.close_error = False
+        self.cursors: list[FakeCursor] = []
+
+    def get_server_version(self) -> str:
+        self.server_version_calls += 1
+        if self.version_error:
+            raise RuntimeError("stale connection")
+        return "11.0"
+
+    def cursor(self) -> FakeCursor:
+        cursor = FakeCursor(self._rows)
+        self.cursors.append(cursor)
+        return cursor
+
+    def close(self) -> None:
+        if self.close_error:
+            raise RuntimeError("close failed")
+        self.closed = True
+
+
+@pytest.fixture
+def patch_connect(monkeypatch: pytest.MonkeyPatch) -> list[FakeConnection]:
+    """Return a list that records every FakeConnection handed out by connect()."""
+    created: list[FakeConnection] = []
+
+    def _connect(**_kwargs: Any) -> FakeConnection:
+        conn = FakeConnection()
+        created.append(conn)
+        return conn
+
+    monkeypatch.setattr(pycubrid, "connect", _connect)
+    return created
+
+
+def test_connect_creates_and_caches_connection(patch_connect: list[FakeConnection]) -> None:
+    db = Database(_TEST_CONFIG)
+    first = db.connect()
+    second = db.connect()
+    assert first is second
+    assert len(patch_connect) == 1
+    # Reuse path validates the cached connection via get_server_version.
+    assert first.server_version_calls == 1
+
+
+def test_connect_discards_stale_connection(patch_connect: list[FakeConnection]) -> None:
+    db = Database(_TEST_CONFIG)
+    first = db.connect()
+    first.version_error = True  # next reuse attempt fails -> discard + reconnect
+    second = db.connect()
+    assert second is not first
+    assert first.closed is True
+    assert len(patch_connect) == 2
+
+
+def test_discard_connection_swallows_close_error(patch_connect: list[FakeConnection]) -> None:
+    db = Database(_TEST_CONFIG)
+    first = db.connect()
+    first.version_error = True
+    first.close_error = True  # close raises during discard; must be swallowed
+    second = db.connect()
+    assert second is not first
+    assert len(patch_connect) == 2
+
+
+def test_close_clears_connection(patch_connect: list[FakeConnection]) -> None:
+    db = Database(_TEST_CONFIG)
+    conn = db.connect()
+    db.close()
+    assert conn.closed is True
+    # A subsequent connect creates a fresh connection.
+    db.connect()
+    assert len(patch_connect) == 2
+
+
+def test_close_when_no_connection_is_noop(patch_connect: list[FakeConnection]) -> None:
+    db = Database(_TEST_CONFIG)
+    db.close()  # should not raise
+    assert patch_connect == []
+
+
+def test_cursor_closes_and_wraps_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(DatabaseError, match="query failed"):
+        with db.cursor():
+            raise ValueError("boom")
+    # Cursor is always closed, even on error.
+    assert conn.cursors[0].closed is True
+
+
+def test_exclusive_yields_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with db.exclusive() as active:
+        assert active is conn
+
+
+def test_fetch_all_returns_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection(rows=[(1,), (2,)])
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    assert db.fetch_all("SELECT 1", None) == [(1,), (2,)]
+    assert conn.cursors[0].executed == [("SELECT 1", ())]
+
+
+def test_fetch_many_truncates_across_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [(i,) for i in range(250)]
+    conn = FakeConnection(rows=rows)
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    result, truncated = db.fetch_many("SELECT x", None, max_rows=150)
+    assert truncated is True
+    assert result == rows[:150]
+
+
+def test_fetch_many_no_truncation_when_max_rows_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [(i,) for i in range(50)]
+    conn = FakeConnection(rows=rows)
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    result, truncated = db.fetch_many("SELECT x", None, max_rows=None)
+    assert truncated is False
+    assert result == rows

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -235,6 +235,26 @@ def test_explain_query_rejects_writes(sql: str, monkeypatch: pytest.MonkeyPatch)
         server.explain_query(sql)
 
 
+def test_explain_query_always_read_only_even_when_readonly_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """explain_query rejects non-SELECT/WITH input regardless of CUBRID_MCP_READONLY (#59)."""
+    write_mode = Config(
+        host="h",
+        port=33000,
+        user="u",
+        password="",
+        database="d",
+        readonly=False,
+        max_chars=4000,
+        max_rows=1000,
+    )
+    monkeypatch.setattr(server, "_db", lambda: _FakeConnDB())
+    monkeypatch.setattr(server, "_config", write_mode)
+    with pytest.raises(ValueError):
+        server.explain_query("DELETE FROM users")
+
+
 # ---------------------------------------------------------------------------
 # E. _quote_ident escaping for table_row_counts identifier interpolation
 # ---------------------------------------------------------------------------

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -25,6 +25,7 @@ _TEST_CONFIG = Config(
     database="d",
     readonly=True,
     max_chars=4000,
+    max_rows=1000,
 )
 
 
@@ -58,6 +59,9 @@ def test_safety_accepts_legitimate_read_variants(sql: str) -> None:
         "RENAME TABLE users TO ex_users",
         "MERGE INTO target USING src ON (1=1) WHEN MATCHED THEN UPDATE SET x=1",
         "CALL my_proc()",
+        "WITH x AS (SELECT 1) DELETE FROM users",
+        "WITH x AS (SELECT 1) INSERT INTO t SELECT * FROM x",
+        "SELECT * FROM users FOR UPDATE",
     ],
 )
 def test_safety_rejects_bypass_attempts(sql: str) -> None:
@@ -161,31 +165,40 @@ class _FakeCursor:
     def fetchall(self) -> list[tuple[Any, ...]]:
         return self._fetch
 
+    def close(self) -> None:
+        pass
+
 
 class _FakeConnDB:
     def __init__(self) -> None:
         self.cursors: list[_FakeCursor] = []
         self.rolled_back = False
 
-    def cursor(self) -> Any:
-        from contextlib import contextmanager
-
-        @contextmanager
-        def _cm() -> Any:
-            cur = _FakeCursor()
-            self.cursors.append(cur)
-            yield cur
-
-        return _cm()
-
-    def connect(self) -> Any:
+    def _make_conn(self) -> Any:
         outer = self
 
         class _Conn:
+            def cursor(self_inner) -> _FakeCursor:
+                cur = _FakeCursor()
+                outer.cursors.append(cur)
+                return cur
+
             def rollback(self_inner) -> None:
                 outer.rolled_back = True
 
         return _Conn()
+
+    def exclusive(self) -> Any:
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm() -> Any:
+            yield self._make_conn()
+
+        return _cm()
+
+    def connect(self) -> Any:
+        return self._make_conn()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,13 +26,21 @@ skipif_no_cubrid = pytest.mark.skipif(
 @skipif_no_cubrid
 class TestCubridIntegration:
     def setup_method(self) -> None:
+        from cubrid_mcp_server import server
         from cubrid_mcp_server.config import Config
         from cubrid_mcp_server.database import Database
 
         self.config = Config.from_env()
         self.db = Database(self.config)
+        # Route the server tool functions at the live database.
+        server._config = self.config
+        server._database = self.db
 
     def teardown_method(self) -> None:
+        from cubrid_mcp_server import server
+
+        server._database = None
+        server._config = None
         self.db.close()
 
     def test_connect(self) -> None:
@@ -46,89 +54,90 @@ class TestCubridIntegration:
         assert len(rows) > 0
 
     def test_all_table_names_tool(self) -> None:
-        rows = self.db.fetch_all(
-            "SELECT class_name FROM db_class WHERE is_system_class = 'NO' ORDER BY class_name"
-        )
-        tables = [r[0] for r in rows]
-        assert isinstance(tables, list)
-
-    def test_schema_definitions_tool(self) -> None:
-        rows = self.db.fetch_all(
-            "SELECT class_name FROM db_class WHERE is_system_class = 'NO' LIMIT 1"
-        )
-        if not rows:
-            pytest.skip("no user tables in database")
-        table = rows[0][0]
-        cols = self.db.fetch_all(
-            "SELECT a.attr_name, a.data_type FROM db_attribute a "
-            "WHERE a.class_name = ? ORDER BY a.def_order",
-            (table,),
-        )
-        assert len(cols) > 0
-
-    def test_execute_query_tool(self) -> None:
-        rows = self.db.fetch_all("SELECT 1 + 1")
-        assert rows[0][0] == 2
-
-    def test_list_indexes_query(self) -> None:
-        rows = self.db.fetch_all(
-            "SELECT class_name FROM db_class WHERE is_system_class='NO' LIMIT 1"
-        )
-        if not rows:
-            pytest.skip("no user tables")
-        table = rows[0][0]
-        result = self.db.fetch_all(
-            "SELECT i.index_name, i.is_unique, i.is_primary_key, i.is_foreign_key, "
-            "i.is_reverse, i.key_count, k.key_attr_name, k.key_order, k.asc_desc "
-            "FROM db_index i, db_index_key k "
-            "WHERE i.class_name = ? AND i.index_name = k.index_name "
-            "AND i.class_name = k.class_name "
-            "ORDER BY i.index_name, k.key_order",
-            (table,),
-        )
-        assert isinstance(result, list)
-
-    def test_list_serials_query(self) -> None:
-        rows = self.db.fetch_all(
-            "SELECT name, current_val, increment_val, max_val, min_val, "
-            "cyclic, started, class_name, att_name, cached_num, comment "
-            "FROM db_serial ORDER BY name"
-        )
-        assert isinstance(rows, list)
-
-    def test_list_class_hierarchy_query(self) -> None:
-        rows = self.db.fetch_all(
-            "SELECT class_name, super_class_name FROM db_direct_super_class "
-            "ORDER BY class_name LIMIT 5"
-        )
-        assert isinstance(rows, list)
-
-    def test_v01_tools_via_server(self) -> None:
         from cubrid_mcp_server import server
 
-        server._database = self.db
-        server._config = self.config
-        try:
-            tables = server.all_table_names()
-            assert isinstance(tables, list)
-            if tables:
-                desc = server.describe_table(tables[0])
-                assert desc["table"] == tables[0]
-                assert "columns" in desc and "indexes" in desc
-                idx = server.list_indexes(tables[0])
-                assert isinstance(idx, list)
-                counts = server.table_row_counts([tables[0]])
-                assert counts[0]["table"] == tables[0]
-            explain = server.explain_query("SELECT COUNT(*) FROM db_class")
-            assert "plan" in explain
-            assert "SELECT" in explain["plan"] or explain["plan"] == ""
-            serials = server.list_serials()
-            assert isinstance(serials, list)
-            hierarchy = server.list_class_hierarchy()
-            assert isinstance(hierarchy, list)
-        finally:
-            server._database = None
-            server._config = None
+        tables = server.all_table_names()
+        assert isinstance(tables, list)
+
+    def test_filter_table_names_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        tables = server.all_table_names()
+        if not tables:
+            pytest.skip("no user tables in database")
+        needle = tables[0][:2]
+        filtered = server.filter_table_names(needle)
+        assert tables[0] in filtered
+
+    def test_schema_definitions_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        tables = server.all_table_names()
+        if not tables:
+            pytest.skip("no user tables in database")
+        cols = server.schema_definitions(tables[0])
+        assert isinstance(cols, list)
+        assert all("name" in c and "type" in c for c in cols)
+
+    def test_describe_table_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        tables = server.all_table_names()
+        if not tables:
+            pytest.skip("no user tables in database")
+        desc = server.describe_table(tables[0])
+        assert desc["table"] == tables[0]
+        assert "columns" in desc and "indexes" in desc
+
+    def test_schema_definitions_unknown_table_raises(self) -> None:
+        from cubrid_mcp_server import server
+
+        with pytest.raises(ValueError):
+            server.schema_definitions("definitely_not_a_real_table_xyz")
+
+    def test_execute_query_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        result = server.execute_query("SELECT 1 + 1")
+        assert result["rows"][0][0] == 2
+        assert result["row_count"] == 1
+        assert result["truncated"] is False
+
+    def test_list_indexes_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        tables = server.all_table_names()
+        if not tables:
+            pytest.skip("no user tables")
+        result = server.list_indexes(tables[0])
+        assert isinstance(result, list)
+
+    def test_table_row_counts_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        tables = server.all_table_names()
+        if not tables:
+            pytest.skip("no user tables")
+        counts = server.table_row_counts([tables[0]])
+        assert counts[0]["table"] == tables[0]
+
+    def test_explain_query_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        explain = server.explain_query("SELECT COUNT(*) FROM db_class")
+        assert "plan" in explain
+
+    def test_list_serials_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        serials = server.list_serials()
+        assert isinstance(serials, list)
+
+    def test_list_class_hierarchy_tool(self) -> None:
+        from cubrid_mcp_server import server
+
+        hierarchy = server.list_class_hierarchy()
+        assert isinstance(hierarchy, list)
 
     def test_safety_blocks_write(self) -> None:
         from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,7 @@ _TEST_CONFIG = Config(
     database="d",
     readonly=True,
     max_chars=4000,
+    max_rows=1000,
 )
 
 
@@ -34,6 +35,17 @@ class FakeDatabase:
         if not self.responses:
             return []
         return self.responses.pop(0)
+
+    def fetch_many(
+        self,
+        sql: str,
+        params: tuple[Any, ...] | None = None,
+        max_rows: int | None = None,
+    ) -> tuple[list[tuple[Any, ...]], bool]:
+        rows = self.fetch_all(sql, params)
+        if max_rows is not None and len(rows) > max_rows:
+            return rows[:max_rows], True
+        return rows, False
 
 
 @pytest.fixture
@@ -59,6 +71,7 @@ def test_filter_table_names_empty(fake_db: FakeDatabase) -> None:
 
 
 def test_schema_definitions(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])  # _resolve_table lookup
     fake_db.queue(
         [
             ("id", "INTEGER", "NO", None),
@@ -86,6 +99,7 @@ def test_schema_definitions(fake_db: FakeDatabase) -> None:
 
 
 def test_list_indexes_groups_columns(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])  # _resolve_table lookup
     fake_db.queue(
         [
             ("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC"),
@@ -102,6 +116,7 @@ def test_list_indexes_groups_columns(fake_db: FakeDatabase) -> None:
 
 
 def test_describe_table(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])  # _resolve_table lookup
     fake_db.queue([("id", "INTEGER", "NO", None)])
     fake_db.queue([("id",)])
     fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
@@ -131,6 +146,9 @@ class FakeCursor:
     def fetchall(self) -> list[tuple[Any, ...]]:
         return self._fetch
 
+    def close(self) -> None:
+        pass
+
 
 class FakeConnDatabase(FakeDatabase):
     def __init__(self) -> None:
@@ -138,28 +156,31 @@ class FakeConnDatabase(FakeDatabase):
         self.cursors: list[FakeCursor] = []
         self.rolled_back = False
 
-    def cursor(self) -> Any:
-        from contextlib import contextmanager
-
-        @contextmanager
-        def _cm() -> Any:
-            cur = FakeCursor(self)
-            self.cursors.append(cur)
-            try:
-                yield cur
-            finally:
-                pass
-
-        return _cm()
-
-    def connect(self) -> Any:
+    def _make_conn(self) -> Any:
         outer = self
 
         class _Conn:
+            def cursor(self_inner) -> FakeCursor:
+                cur = FakeCursor(outer)
+                outer.cursors.append(cur)
+                return cur
+
             def rollback(self_inner) -> None:
                 outer.rolled_back = True
 
         return _Conn()
+
+    def exclusive(self) -> Any:
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm() -> Any:
+            yield self._make_conn()
+
+        return _cm()
+
+    def connect(self) -> Any:
+        return self._make_conn()
 
 
 def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -272,11 +293,12 @@ def test_execute_query_renders_and_truncates(
         database="d",
         readonly=True,
         max_chars=10,
+        max_rows=1000,
     )
     monkeypatch.setattr(server, "_config", cfg)
     fake_db.queue([("short",), ("a-much-longer-row",)])
     result = server.execute_query("SELECT 1")
-    assert result["row_count"] == 2
+    assert result["row_count"] == 1
     assert result["truncated"] is True
 
 
@@ -284,4 +306,5 @@ def test_render_rows_returns_first_row_when_oversized() -> None:
     rows = [("a-very-long-first-row",), ("short",)]
     out = server._render_rows(rows, max_chars=5)
     assert out["truncated"] is True
-    assert out["rows"] == [["a-very-long-first-row"]]
+    # The single oversized value is itself truncated to the char budget.
+    assert out["rows"] == [["a-ve\u2026"]]


### PR DESCRIPTION
## Summary

Implements all filed tracker issues (#33–#60) across six logical commits, organized by milestone. All unit tests, ruff, ruff-format, and mypy (strict) pass locally (126 passed), and coverage is 99% (enforcing the #50 gate).

## Commits

1. **fix: harden read-only safety, connection handling, and query limits** (v0.2.1)
   - safety: full token-stream deny-scan rejects embedded DML — CTE `WITH…DELETE`, `SELECT…FOR UPDATE` (#40)
   - database: close stale connections before discard, `RLock` + `exclusive()`, streaming `fetch_many()`, masked connect errors (#33, #39, #41)
   - config: `password` excluded from `repr()`, new `CUBRID_MCP_MAX_ROWS` (#34, #37)
   - server: helper/tool split, catalog-backed `_resolve_table`, per-value truncation with honest `row_count`, locked `SET TRACE/SHOW TRACE`, 50-table cap, base64 binary, fail-fast `main()` (#35, #38, #42–#48)

2. **build: pin fastmcp 3.x, dynamic version, py.typed, and CI/publish hardening** (v0.2.2)
   - `fastmcp>=3.0,<4`, dynamic version, `py.typed`, drop `--maxfail=25` (#35, #54, #55, #60)
   - CI coverage + lowest-direct resolution job (#50, #51)
   - publish: tag/version check, `twine check`, attestations (#56)

3. **docs: correct security guidance, repo org, changelog, and integration tests**
   - SECURITY per-table GRANT, max-rows/binary notes, version fix (#49)
   - `cubrid-labs` → `cubrid-lab` (#53)
   - CHANGELOG Unreleased + 0.2.0 note (#58)
   - integration tests rewritten to exercise `server.*` tools end-to-end (#52)

4. **docs: document stdio stdout-pollution constraint and stderr logging** (#57)

5. **fix: make read-only policy explicit for explain_query and document source install**
   - `explain_query` is intentionally always read-only regardless of `CUBRID_MCP_READONLY`; documented in code + SECURITY.md with a regression test (#59)
   - README documents install-from-source path and notes PyPI publishing is pending until the first release (#36)

6. **test: cover database, server error paths, and safety recursion**
   - Mock-based unit tests (no live CUBRID) raise coverage from 78% to 99%, satisfying the enforced `fail_under=95` gate (#50)

## Verification

- `ruff check .` ✓
- `ruff format --check .` ✓
- `mypy cubrid_mcp_server` (strict) ✓
- `pytest -m "not integration"` → 126 passed, 99% coverage ✓
- Integration tests updated (require a live CUBRID; run in CI)

## Closes

Closes #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60
