### PR TITLE
ci: add CodeQL workflow + dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,20 @@
+name: CodeQL Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    uses: cubrid-lab/.github/.github/workflows/codeql.yml@main
+    with:
+      language: python


### PR DESCRIPTION
## Summary

- Add `.github/workflows/codeql.yml` using org-level reusable workflow (`cubrid-lab/.github/.github/workflows/codeql.yml@main`)
- Add `.github/dependabot.yml` covering `pip` and `github-actions` ecosystems (weekly)

Completes `cubrid-lab/.github#11` acceptance criteria for this repo.

Refs cubrid-lab/.github#11