### PR TITLE
security: pin sqlparse<1 and strip SQL comments before safety check

### DIFF
--- a/cubrid_mcp_server/safety.py
+++ b/cubrid_mcp_server/safety.py
@@ -50,6 +50,16 @@ FORBIDDEN_KEYWORDS: frozenset[str] = frozenset(
 )
 
 
+def _strip_comments(sql: str) -> str:
+    """Remove SQL comments before safety check.
+
+    ``sqlparse`` can be confused by keywords inside comments (e.g.
+    ``/* DROP TABLE */`` or ``-- DELETE FROM users``). Stripping
+    comments ensures the safety checker only scans real SQL tokens.
+    """
+    return sqlparse.format(sql, strip_comments=True)
+
+
 class UnsafeSQLError(ValueError):
     """Raised when a statement is rejected by the read-only checker."""
 
@@ -58,6 +68,10 @@ def ensure_read_only(sql: str) -> None:
     """Raise :class:`UnsafeSQLError` if ``sql`` is not a single read-only statement."""
     if not sql or not sql.strip():
         raise UnsafeSQLError("empty SQL statement")
+
+    # Strip comments before parsing — keywords inside comments could
+    # confuse the safety checker (defence-in-depth).
+    sql = _strip_comments(sql)
 
     statements = [stmt for stmt in sqlparse.parse(sql) if _is_non_empty(stmt)]
     if len(statements) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=3.0,<4",
     "pycubrid>=1.4,<2",
-    "sqlparse>=0.5",
+    "sqlparse>=0.5,<1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -79,6 +79,23 @@ def test_safety_rejects_only_block_comment() -> None:
         ensure_read_only("/* nothing here */")
 
 
+def test_safety_strips_line_comment_before_check() -> None:
+    """Keywords inside line comments must not trigger false rejections."""
+    # SELECT is the real statement; DROP in the comment must be ignored
+    ensure_read_only("SELECT 1 -- DROP TABLE users")
+
+
+def test_safety_strips_block_comment_before_check() -> None:
+    """Keywords inside block comments must not trigger false rejections."""
+    ensure_read_only("SELECT 1 /* DELETE FROM users */")
+
+
+def test_safety_comment_does_not_bypass_forbidden_keyword() -> None:
+    """A real forbidden keyword after the comment is still caught."""
+    with pytest.raises(UnsafeSQLError):
+        ensure_read_only("SELECT 1 /* comment */ ; DROP TABLE users")
+
+
 # ---------------------------------------------------------------------------
 # B. _render_rows truncation behavior
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Oracle review Priority 1: the `sqlparse` dependency had no upper bound, and SQL comments containing keywords could confuse the safety checker.

### Changes

1. **Pin `sqlparse>=0.5,<1`** — safety-critical dependency must not float on a major version
2. **Add `_strip_comments()`** — removes SQL comments (`-- ...`, `/* ... */`) before `ensure_read_only()` scans tokens
3. **3 regression tests**: line comment, block comment, multi-statement with comment

### Verification

- `ruff check` ✓
- `ruff format --check` ✓
- `mypy` ✓
- `pytest` → 129 passed (126 + 3 new) ✓

Closes #73