### PR TITLE
ci: add weekly upstream-canary job (pycubrid@main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,18 @@ jobs:
         run: pip install packaging
       - name: Lint CHANGELOG.md
         run: python scripts/lint_changelog.py
+
+  upstream-canary:
+    name: Test against pycubrid@main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    schedule:
+      - cron: "0 6 * * 1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
+      - run: pytest -m "not integration" -q


### PR DESCRIPTION
## Summary

Oracle review Priority 4: add a weekly canary CI job that installs pycubrid from `main` branch and runs the offline test suite. This catches breakage from upstream changes before they reach a release.

### Changes

- New `upstream-canary` job: weekly schedule (Monday 06:00 UTC)
- Installs pycubrid from `git+https://github.com/cubrid-lab/pycubrid.git@main`
- Runs offline test suite
- `continue-on-error: true` — warns without gating PRs

Closes #75