### PR TITLE
fix: move upstream-canary to separate workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,18 +131,3 @@ jobs:
         run: pip install packaging
       - name: Lint CHANGELOG.md
         run: python scripts/lint_changelog.py
-
-  upstream-canary:
-    name: Test against pycubrid@main
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    schedule:
-      - cron: "0 6 * * 1"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: pip install -e ".[dev]"
-      - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
-      - run: pytest -m "not integration" -q

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -1,0 +1,20 @@
+name: Upstream Canary
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  upstream-canary:
+    name: Test against pycubrid@main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
+      - run: pytest -m "not integration" -q


### PR DESCRIPTION
## Summary

Oracle 2nd-pass review found that the `upstream-canary` job had `schedule:` at the **job level** — GitHub Actions requires it at the **workflow level** (`on: schedule:`). The canary never actually triggered on schedule.

### Changes

- Remove `upstream-canary` job from `ci.yml`
- Create `.github/workflows/upstream-canary.yml` with `on: schedule:` + `workflow_dispatch:` at workflow level

Closes #81