### PR TITLE
fix: remove duplicated blocks left by #86 that restart the server and break CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `main()` no longer starts a second MCP server after the first one shuts down; the duplicated tail of the function (logging setup, config parse, and a second `mcp.run()`) has been removed. (#87)
+- Removed the duplicated, unreachable copies of the `fetch_all` body in `Database` and of the empty-SQL guard in `explain_query`. (#87)
+
+### Added
+- Tests for `CUBRID_MCP_MAX_SQL_LENGTH` and `CUBRID_MCP_QUERY_TIMEOUT` parsing/validation, and for oversized-SQL rejection in `execute_query` and `explain_query`. (#87)
+
 ## [0.2.1] - 2026-08-06
 
 ### Security

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -89,9 +89,6 @@ class Database:
         with self.cursor() as cursor:
             cursor.execute(sql, params or ())
             return list(cursor.fetchall())
-        with self.cursor() as cursor:
-            cursor.execute(sql, params or ())
-            return list(cursor.fetchall())
 
     def fetch_many(
         self,

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -182,8 +182,6 @@ def explain_query(sql: str) -> dict[str, Any]:
             f"SQL exceeds maximum length of {config.max_sql_length} characters "
             f"(CUBRID_MCP_MAX_SQL_LENGTH)"
         )
-    if not cleaned:
-        raise ValueError("empty SQL statement")
     leading = cleaned.split(None, 1)[0].upper()
     if leading not in {"SELECT", "WITH"}:
         raise ValueError("explain_query only accepts SELECT or WITH statements")
@@ -393,19 +391,4 @@ def main() -> None:
             _database.close()
 
     atexit.register(_cleanup)
-    mcp.run()
-    # The MCP stdio transport uses stdout as the protocol channel, so ALL logging
-    # must go to stderr — a stray log line on stdout corrupts the JSON-RPC stream.
-    logging.basicConfig(
-        stream=sys.stderr,
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    # Fail fast with a clear message if configuration is missing/invalid, rather than
-    # surfacing the error on the first tool call.
-    try:
-        Config.from_env()
-    except ConfigError as exc:
-        print(f"configuration error: {exc}", file=sys.stderr)
-        raise SystemExit(1) from exc
     mcp.run()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,32 @@ def test_from_env_invalid_max_rows() -> None:
         Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_ROWS": "0"})
 
 
+def test_from_env_max_sql_length_default_and_override() -> None:
+    assert Config.from_env(BASE_ENV).max_sql_length == 65536
+    cfg = Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_SQL_LENGTH": "1024"})
+    assert cfg.max_sql_length == 1024
+
+
+def test_from_env_invalid_max_sql_length() -> None:
+    with pytest.raises(ConfigError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_SQL_LENGTH": "big"})
+    with pytest.raises(ConfigError, match="positive"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_MAX_SQL_LENGTH": "0"})
+
+
+def test_from_env_query_timeout_default_and_override() -> None:
+    assert Config.from_env(BASE_ENV).query_timeout == 30.0
+    cfg = Config.from_env(BASE_ENV | {"CUBRID_MCP_QUERY_TIMEOUT": "2.5"})
+    assert cfg.query_timeout == 2.5
+
+
+def test_from_env_invalid_query_timeout() -> None:
+    with pytest.raises(ConfigError, match="CUBRID_MCP_QUERY_TIMEOUT"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_QUERY_TIMEOUT": "soon"})
+    with pytest.raises(ConfigError, match="positive"):
+        Config.from_env(BASE_ENV | {"CUBRID_MCP_QUERY_TIMEOUT": "0"})
+
+
 def test_password_not_in_repr() -> None:
     cfg = Config.from_env(BASE_ENV)
     assert "secret" not in repr(cfg)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -199,21 +199,21 @@ def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_db", FakeConnDatabase)
     monkeypatch.setattr(server, "_config", _TEST_CONFIG)
     with pytest.raises(ValueError):
         server.explain_query("DROP TABLE users")
 
 
 def test_explain_query_rejects_multistatement(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_db", FakeConnDatabase)
     monkeypatch.setattr(server, "_config", _TEST_CONFIG)
     with pytest.raises((ValueError, UnsafeSQLError)):
         server.explain_query("SELECT 1; DROP TABLE users")
 
 
 def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_db", FakeConnDatabase)
     monkeypatch.setattr(server, "_config", _TEST_CONFIG)
     with pytest.raises(ValueError):
         server.explain_query("   ")
@@ -223,7 +223,7 @@ _SHORT_SQL_CONFIG = replace(_TEST_CONFIG, max_sql_length=32)
 
 
 def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_db", FakeConnDatabase)
     monkeypatch.setattr(server, "_config", _SHORT_SQL_CONFIG)
     with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
         server.explain_query("SELECT " + "a" * 100)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -216,6 +217,26 @@ def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "_config", _TEST_CONFIG)
     with pytest.raises(ValueError):
         server.explain_query("   ")
+
+
+_SHORT_SQL_CONFIG = replace(_TEST_CONFIG, max_sql_length=32)
+
+
+def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_db", lambda: FakeConnDatabase())
+    monkeypatch.setattr(server, "_config", _SHORT_SQL_CONFIG)
+    with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
+        server.explain_query("SELECT " + "a" * 100)
+
+
+def test_execute_query_rejects_oversized_sql(
+    fake_db: FakeDatabase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(server, "_config", _SHORT_SQL_CONFIG)
+    with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
+        server.execute_query("SELECT " + "a" * 100)
+    # The oversized statement is rejected before it ever reaches the database.
+    assert fake_db.calls == []
 
 
 def test_table_row_counts_explicit(fake_db: FakeDatabase) -> None:


### PR DESCRIPTION
Fixes the red `main`.

## What was wrong

`main` has been failing all four `lint-and-test` matrix jobs since 8064166 (#86) — every test passes, but coverage lands at 94.49% against a 95% gate. The uncovered lines turned out to be three duplicated blocks that commit left behind, not missing tests.

**`server.py` — the server started a second time after shutdown.** `main()` had its whole tail duplicated after `mcp.run()`. `mcp.run()` returns when the stdio transport shuts down, so on a normal exit the process reconfigured logging, re-parsed config, and started another MCP server. Coverage never flagged it as a bug because no unit test drives `main()` to completion — it just showed up as uncovered lines.

**`database.py`** — the `fetch_all` body appeared twice, the second copy unreachable after the first `return`.

**`server.py`** — `explain_query` had the same `if not cleaned: raise ValueError(...)` guard twice, with `cleaned` unchanged in between.

## What this PR does

- Removes the three duplicated blocks.
- Adds the tests #82/#83 shipped without: `CUBRID_MCP_MAX_SQL_LENGTH` and `CUBRID_MCP_QUERY_TIMEOUT` parsing/validation, and oversized-SQL rejection in both `execute_query` and `explain_query` (asserting the statement is rejected before it reaches the database).

No behavior change beyond not running the server twice.

## Verification

```
ruff check .            All checks passed!
ruff format --check .   15 files already formatted
mypy cubrid_mcp_server  Success: no issues found in 6 source files
lint_changelog.py       OK: 3 version(s), order valid
pytest -m "not integration" --cov
                        135 passed, 14 deselected
                        coverage 94.49% -> 98.19%
```

Closes #87
