### PR TITLE
fix: enforce query_timeout as socket read timeout (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Optional settings:
 |----------|---------|-------------|
 | `CUBRID_MCP_READONLY` | `1` | Enforce read-only SQL whitelist |
 | `CUBRID_MCP_MAX_CHARS` | `4000` | Max characters in query output |
+| `CUBRID_MCP_MAX_ROWS` | `1000` | Max rows returned by `execute_query` before truncation |
+| `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
+| `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
 
 ### Run
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -110,8 +110,7 @@ class Database:
         # reusing a corrupt session.
         self._discard_connection()
         return QueryTimeoutError(
-            f"query exceeded timeout of {self._config.query_timeout:g}s "
-            f"(CUBRID_MCP_QUERY_TIMEOUT)"
+            f"query exceeded timeout of {self._config.query_timeout:g}s (CUBRID_MCP_QUERY_TIMEOUT)"
         )
 
     @contextmanager

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+import socket
 import threading
 from contextlib import contextmanager
 from typing import Any, Iterator
+
 
 import pycubrid
 
@@ -16,6 +18,27 @@ logger = logging.getLogger(__name__)
 
 class DatabaseError(RuntimeError):
     """Raised when a database operation fails."""
+
+
+class QueryTimeoutError(DatabaseError):
+    """Raised when a statement exceeds the configured read timeout."""
+
+
+def _is_timeout_error(exc: BaseException | None) -> bool:
+    """Return ``True`` if ``exc`` (or any error in its chain) is a socket timeout.
+
+    ``read_timeout`` is enforced as a socket ``settimeout``; a slow statement
+    surfaces as :class:`socket.timeout`/:class:`TimeoutError`, which pycubrid
+    re-wraps as an ``OperationalError`` with the timeout preserved as its
+    ``__cause__``. Walking the chain catches both the raw and wrapped forms.
+    """
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, (socket.timeout, TimeoutError)):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
 
 
 class Database:
@@ -42,6 +65,12 @@ class Database:
                 password=self._config.password,
                 database=self._config.database,
                 connect_timeout=10,
+                # Bound how long a single statement may block the shared
+                # connection. This is a socket read timeout (not a true
+                # server-side statement timeout): if the broker sends no bytes
+                # for this many seconds the read aborts and we discard the
+                # now-unusable connection. See CUBRID_MCP_QUERY_TIMEOUT.
+                read_timeout=self._config.query_timeout,
             )
         except Exception as exc:  # pragma: no cover - driver-specific
             raise DatabaseError(
@@ -67,23 +96,54 @@ class Database:
             finally:
                 self._connection = None
 
+    @staticmethod
+    def _safe_close_cursor(cursor: Any) -> None:
+        try:
+            cursor.close()
+        except Exception as exc:
+            logger.debug("failed to close cursor: %s", exc)
+
+    def _timeout_error(self, exc: BaseException) -> QueryTimeoutError:
+        """Discard the corrupt connection and build a clear timeout error."""
+        # The socket timed out mid-statement, so the connection buffer is now
+        # in an unknown state; drop it so the next call reconnects instead of
+        # reusing a corrupt session.
+        self._discard_connection()
+        return QueryTimeoutError(
+            f"query exceeded timeout of {self._config.query_timeout:g}s "
+            f"(CUBRID_MCP_QUERY_TIMEOUT)"
+        )
+
     @contextmanager
     def cursor(self) -> Iterator[Any]:
         with self._lock:
             connection = self.connect()
             cursor = connection.cursor()
+            timed_out = False
             try:
                 yield cursor
             except Exception as exc:
+                if _is_timeout_error(exc):
+                    timed_out = True
+                    raise self._timeout_error(exc) from exc
                 raise DatabaseError(f"query failed: {exc}") from exc
             finally:
-                cursor.close()
+                # After a timeout the connection is already discarded and the
+                # socket is dead; closing the cursor would only block again.
+                if not timed_out:
+                    self._safe_close_cursor(cursor)
 
     @contextmanager
     def exclusive(self) -> Iterator[Any]:
         """Hold the connection lock across multiple statements (e.g. SET TRACE ... SHOW TRACE)."""
         with self._lock:
-            yield self.connect()
+            connection = self.connect()
+            try:
+                yield connection
+            except Exception as exc:
+                if _is_timeout_error(exc):
+                    raise self._timeout_error(exc) from exc
+                raise
 
     def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         with self.cursor() as cursor:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,13 +6,19 @@ fetch logic without a live CUBRID server by monkeypatching ``pycubrid.connect``.
 
 from __future__ import annotations
 
+import socket
 from typing import Any
 
 import pytest
 
 import pycubrid
 from cubrid_mcp_server.config import Config
-from cubrid_mcp_server.database import Database, DatabaseError
+from cubrid_mcp_server.database import (
+    Database,
+    DatabaseError,
+    QueryTimeoutError,
+    _is_timeout_error,
+)
 
 _TEST_CONFIG = Config(
     host="h",
@@ -179,3 +185,143 @@ def test_fetch_many_no_truncation_when_max_rows_none(monkeypatch: pytest.MonkeyP
     result, truncated = db.fetch_many("SELECT x", None, max_rows=None)
     assert truncated is False
     assert result == rows
+
+
+# --- query_timeout enforcement (issue #101) ---
+
+
+class TimeoutCursor(FakeCursor):
+    """Cursor whose ``execute`` raises a socket timeout, simulating a slow query."""
+
+    def __init__(self, error: BaseException) -> None:
+        super().__init__()
+        self._error = error
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        raise self._error
+
+
+class TimeoutConnection(FakeConnection):
+    def __init__(self, error: BaseException) -> None:
+        super().__init__()
+        self._error = error
+
+    def cursor(self) -> FakeCursor:
+        cursor = TimeoutCursor(self._error)
+        self.cursors.append(cursor)
+        return cursor
+
+
+def test_connect_passes_query_timeout_as_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _connect(**kwargs: Any) -> FakeConnection:
+        captured.update(kwargs)
+        return FakeConnection()
+
+    monkeypatch.setattr(pycubrid, "connect", _connect)
+    config = Config(
+        host="h",
+        port=33000,
+        user="u",
+        password="",
+        database="d",
+        readonly=True,
+        max_chars=4000,
+        max_rows=1000,
+        query_timeout=12.5,
+    )
+    Database(config).connect()
+    assert captured["read_timeout"] == 12.5
+
+
+def test_is_timeout_error_detects_raw_and_wrapped() -> None:
+    assert _is_timeout_error(TimeoutError("slow")) is True
+    assert _is_timeout_error(socket.timeout("slow")) is True
+    # pycubrid wraps the socket timeout as another error with __cause__ set.
+    wrapped = RuntimeError("socket communication failed")
+    wrapped.__cause__ = TimeoutError("timed out")
+    assert _is_timeout_error(wrapped) is True
+    assert _is_timeout_error(RuntimeError("syntax error")) is False
+    assert _is_timeout_error(None) is False
+
+
+def test_cursor_timeout_raises_and_discards_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = TimeoutConnection(TimeoutError("read timed out"))
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(QueryTimeoutError, match="query exceeded timeout"):
+        db.fetch_all("SELECT SLEEP(999)")
+    # The corrupt connection must be dropped so the next call reconnects.
+    assert conn.closed is True
+    assert db._connection is None
+
+
+def test_cursor_timeout_detects_wrapped_operational_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrapped = RuntimeError("socket communication failed")
+    wrapped.__cause__ = TimeoutError("timed out")
+    conn = TimeoutConnection(wrapped)
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(QueryTimeoutError):
+        db.fetch_all("SELECT SLEEP(999)")
+    assert db._connection is None
+
+
+def test_non_timeout_error_still_wrapped_as_database_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = TimeoutConnection(ValueError("bad syntax"))
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(DatabaseError, match="query failed") as excinfo:
+        db.fetch_all("SELECT bogus")
+    assert not isinstance(excinfo.value, QueryTimeoutError)
+    # A plain query error does not invalidate the connection.
+    assert db._connection is conn
+
+
+def test_exclusive_timeout_raises_and_discards_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = FakeConnection()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(QueryTimeoutError):
+        with db.exclusive():
+            raise TimeoutError("read timed out")
+    assert conn.closed is True
+    assert db._connection is None
+
+
+def test_exclusive_reraises_non_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with pytest.raises(ValueError, match="boom"):
+        with db.exclusive():
+            raise ValueError("boom")
+    # A non-timeout error leaves the connection intact for reuse.
+    assert db._connection is conn
+
+
+def test_cursor_close_error_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection(rows=[(1,)])
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+
+    def _boom() -> None:
+        raise RuntimeError("close failed")
+
+    # fetch_all succeeds even if cursor.close() raises during cleanup.
+    original_cursor = conn.cursor
+
+    def _cursor() -> FakeCursor:
+        cur = original_cursor()
+        cur.close = _boom  # type: ignore[method-assign]
+        return cur
+
+    monkeypatch.setattr(conn, "cursor", _cursor)
+    assert db.fetch_all("SELECT 1") == [(1,)]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -32,6 +32,15 @@ _TEST_CONFIG = Config(
 )
 
 
+def _raise(exc: BaseException) -> None:
+    """Raise ``exc`` from inside a block.
+
+    Routing the raise through a helper keeps static analyzers from treating the
+    statements after a ``with pytest.raises(...)`` guard as unreachable.
+    """
+    raise exc
+
+
 class FakeCursor:
     def __init__(self, rows: list[tuple[Any, ...]] | None = None) -> None:
         self._rows = list(rows or [])
@@ -146,7 +155,7 @@ def test_cursor_closes_and_wraps_errors(monkeypatch: pytest.MonkeyPatch) -> None
     db = Database(_TEST_CONFIG)
     with pytest.raises(DatabaseError, match="query failed"):
         with db.cursor():
-            raise ValueError("boom")
+            _raise(ValueError("boom"))
     # Cursor is always closed, even on error.
     assert conn.cursors[0].closed is True
 
@@ -291,7 +300,7 @@ def test_exclusive_timeout_raises_and_discards_connection(
     db = Database(_TEST_CONFIG)
     with pytest.raises(QueryTimeoutError):
         with db.exclusive():
-            raise TimeoutError("read timed out")
+            _raise(TimeoutError("read timed out"))
     assert conn.closed is True
     assert db._connection is None
 
@@ -302,7 +311,7 @@ def test_exclusive_reraises_non_timeout_error(monkeypatch: pytest.MonkeyPatch) -
     db = Database(_TEST_CONFIG)
     with pytest.raises(ValueError, match="boom"):
         with db.exclusive():
-            raise ValueError("boom")
+            _raise(ValueError("boom"))
     # A non-timeout error leaves the connection intact for reuse.
     assert db._connection is conn
 


### PR DESCRIPTION
## Summary
- `query_timeout` was validated in `Config` but never used — only a hardcoded `connect_timeout=10` was in effect, so `CUBRID_MCP_QUERY_TIMEOUT` silently did nothing (dead config flagged in the Oracle design review).
- Wire it to pycubrid's `read_timeout` (socket `settimeout`). On a slow statement the socket raises `TimeoutError` (wrapped by pycubrid as `OperationalError`); we detect it by walking the exception chain, raise a clear `QueryTimeoutError`, and discard the now-corrupt shared connection so the next call reconnects.
- Document `CUBRID_MCP_QUERY_TIMEOUT`, `CUBRID_MCP_MAX_ROWS`, and `CUBRID_MCP_MAX_SQL_LENGTH` in the README optional-settings table.

## Notes
This is a **socket read timeout**, not a true server-side statement timeout (documented as such). It reliably bounds how long a statement can block the shared connection.

## Tests
- New tests: read_timeout wiring, chain detection (raw + wrapped), timeout → `QueryTimeoutError` + connection discard, non-timeout errors still wrapped as `DatabaseError` without dropping the connection, `exclusive()` timeout path.
- `ruff` clean, `mypy --strict` clean, 143 unit tests pass, `database.py` at 100% coverage.

Closes #101