### PR TITLE
test: lock in SQL read-only checker edge cases (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Add to `.cursor/mcp.json`:
 
 The server is **read-only by default**. A code-level SQL whitelist allows only `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, and `WITH` statements. Multi-statement queries are rejected.
 
+> **The SQL whitelist is defense-in-depth, not a security boundary.** It is a non-validating parser-based guardrail against obvious mistakes. The real enforcement layer is the database itself: **always run the server as a CUBRID user that has only `SELECT` grants** on the tables the model may read. See [`SECURITY.md`](./SECURITY.md).
+
 For production use, also configure a read-only database user. See [`SECURITY.md`](./SECURITY.md) for the recommended setup.
 
 ## Logging

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Set the required environment variables:
 ```bash
 export CUBRID_HOST=localhost
 export CUBRID_PORT=33000        # optional, default: 33000
-export CUBRID_USER=dba
+export CUBRID_USER=readonly_user   # a CUBRID user with SELECT-only grants (see Security)
 export CUBRID_PASSWORD=secret
 export CUBRID_DATABASE=mydb
 ```
@@ -80,7 +80,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
       "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
-        "CUBRID_USER": "dba",
+        "CUBRID_USER": "readonly_user",
         "CUBRID_PASSWORD": "secret",
         "CUBRID_DATABASE": "mydb"
       }
@@ -101,7 +101,7 @@ Add to `.mcp.json` in your project root:
       "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
-        "CUBRID_USER": "dba",
+        "CUBRID_USER": "readonly_user",
         "CUBRID_PASSWORD": "secret",
         "CUBRID_DATABASE": "mydb"
       }
@@ -122,7 +122,7 @@ Add to `.cursor/mcp.json`:
       "args": ["cubrid-mcp-server"],
       "env": {
         "CUBRID_HOST": "localhost",
-        "CUBRID_USER": "dba",
+        "CUBRID_USER": "readonly_user",
         "CUBRID_PASSWORD": "secret",
         "CUBRID_DATABASE": "mydb"
       }

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -105,4 +105,3 @@ def test_ensure_read_only_allows_safe_edge_cases(sql: str) -> None:
 def test_ensure_read_only_rejects_hidden_writes(sql: str) -> None:
     with pytest.raises(UnsafeSQLError):
         ensure_read_only(sql)
-        ensure_read_only(sql)

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -53,3 +53,56 @@ def test_ensure_read_only_rejects_select_then_drop() -> None:
 def test_ensure_read_only_rejects_empty(sql: str) -> None:
     with pytest.raises(UnsafeSQLError, match="empty"):
         ensure_read_only(sql)
+
+
+# --- Edge cases locking in defense-in-depth behavior (issue #102) ---
+#
+# These document the *intended* behavior of the sqlparse-based checker. The
+# checker is a UX guardrail, NOT a security boundary: database-level read-only
+# grants are the real enforcement layer (see SECURITY.md). The cases below
+# confirm that keyword-shaped text inside comments, string literals, and quoted
+# identifiers does not cause false positives, while genuine mutating keywords
+# (including inside CTEs, FOR UPDATE, and INTO) are rejected.
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Keywords inside block/line comments are stripped before scanning.
+        "SELECT /* DROP TABLE x */ 1",
+        "SELECT * FROM t -- DELETE FROM t\n",
+        # Keywords inside string literals are tokenized as strings, not keywords.
+        "SELECT 'DELETE FROM users' AS note",
+        "SELECT 'DROP', 'INSERT' FROM t",
+        # Quoted identifiers that happen to spell a forbidden keyword are names.
+        'SELECT "into" FROM t',
+        'SELECT "call" FROM t',
+        # A column alias containing a forbidden word as a substring is fine.
+        "SELECT col AS into_thing FROM t",
+        # A function whose name embeds a forbidden keyword is a Name, not a keyword.
+        "select insert_something(1) from t",
+        # Ordinary read-only CTEs and function calls.
+        "WITH x AS (SELECT 1) SELECT * FROM x",
+        "SELECT COUNT(*) FROM t",
+        "SELECT LENGTH(name) FROM t",
+    ],
+)
+def test_ensure_read_only_allows_safe_edge_cases(sql: str) -> None:
+    ensure_read_only(sql)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # A mutating statement hidden inside a CTE body is still rejected.
+        "WITH x AS (DELETE FROM t RETURNING *) SELECT 1",
+        # Row-level locking escapes read-only mode.
+        "SELECT * FROM t FOR UPDATE",
+        # SELECT ... INTO can write to files/variables and is rejected.
+        "SELECT * INTO OUTFILE '/tmp/x' FROM t",
+    ],
+)
+def test_ensure_read_only_rejects_hidden_writes(sql: str) -> None:
+    with pytest.raises(UnsafeSQLError):
+        ensure_read_only(sql)
+        ensure_read_only(sql)


### PR DESCRIPTION
## Summary
Per the Oracle design review, the `sqlparse`-based `ensure_read_only()` is a **UX guardrail, not a security boundary**. This PR pins its intended behavior with tests and clarifies the docs — no behavior change to the checker (it already behaves correctly).

- **New passing (allowed) edge cases** — confirm no false positives: forbidden keywords inside block/line comments, inside string literals (`'DELETE FROM users'`), inside quoted identifiers (`"into"`, `"call"`), as alias/function-name substrings (`into_thing`, `insert_something(1)`), plus normal CTEs and function calls.
- **New rejected edge cases** — confirm hidden writes are blocked: CTE body `DELETE`, `SELECT ... FOR UPDATE`, `SELECT ... INTO OUTFILE`.
- **Docs** — README Security section now states plainly that the whitelist is defense-in-depth and that a **SELECT-only CUBRID user is the real enforcement layer** (SECURITY.md already documents Layer-1 setup in detail).

## Tests
`ruff` clean, `tests/test_safety.py` 37 passed (14 new).

Closes #102