### PR TITLE
docs: document single-connection + RLock concurrency model (#103)

### DIFF
--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -19,7 +19,27 @@ class DatabaseError(RuntimeError):
 
 
 class Database:
-    """Lazily opens and reuses a single pycubrid connection."""
+    """Lazily opens and reuses a single pycubrid connection.
+
+    Concurrency model
+    -----------------
+    The server intentionally holds **one** pycubrid connection for the whole
+    process, guarded by a single ``threading.RLock``. Every ``cursor()`` /
+    ``exclusive()`` / ``fetch_*`` call acquires that lock, so **all database
+    work is fully serialized** — only one statement runs at a time, regardless
+    of how many tool calls arrive.
+
+    This is a deliberate fit for the MCP **stdio** transport, which serves a
+    single client whose requests are already effectively sequential. A single
+    serialized connection keeps CUBRID session state (e.g. ``SET TRACE`` used
+    by ``explain_query``, transaction/rollback state) coherent and makes the
+    lifecycle trivial to reason about and test.
+
+    A connection **pool is intentionally not used**. It would add session-state
+    isolation, cleanup, and test complexity with no benefit at this scope. Only
+    introduce concurrency (e.g. per-query disposable connections) if stdio
+    serialization is ever shown, by measurement, to be a real bottleneck.
+    """
 
     def __init__(self, config: Config) -> None:
         self._config = config

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -24,10 +24,12 @@ class Database:
     Concurrency model
     -----------------
     The server intentionally holds **one** pycubrid connection for the whole
-    process, guarded by a single ``threading.RLock``. Every ``cursor()`` /
-    ``exclusive()`` / ``fetch_*`` call acquires that lock, so **all database
-    work is fully serialized** — only one statement runs at a time, regardless
-    of how many tool calls arrive.
+    process, guarded by a single ``threading.RLock``. Every statement-executing
+    path — ``cursor()`` / ``exclusive()`` / ``fetch_*`` — acquires that lock, so
+    **query execution is fully serialized**: only one statement runs at a time,
+    regardless of how many tool calls arrive. (The ``connect()`` / ``close()``
+    lifecycle helpers are not themselves lock-guarded; they are expected to run
+    outside concurrent query load, e.g. at startup and shutdown.)
 
     This is a deliberate fit for the MCP **stdio** transport, which serves a
     single client whose requests are already effectively sequential. A single


### PR DESCRIPTION
## Summary
Documents the concurrency model in the `Database` class docstring, per the Oracle design review:
- One process-wide pycubrid connection guarded by a single `threading.RLock` → all DB work is fully serialized (one statement at a time).
- This deliberately fits the single-client MCP **stdio** transport and keeps CUBRID session state (`SET TRACE`, transactions) coherent.
- A connection **pool is intentionally avoided**; only introduce concurrency (e.g. per-query disposable connections) if serialization is *measured* to be a bottleneck.

Docs-only; no behavior change. `ruff`/`mypy` clean, 135 unit tests pass.

Closes #103