### PR TITLE
refactor: encapsulate explain_query SET TRACE lifecycle in Database (#104)

### DIFF
--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -197,12 +197,17 @@ class Database:
         cleanup_errors: list[str] = []
         try:
             cursor = connection.cursor()
-            try:
-                cursor.execute("SET TRACE OFF", ())
-            finally:
-                cursor.close()
         except Exception as exc:
             cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
+        else:
+            try:
+                cursor.execute("SET TRACE OFF", ())
+            except Exception as exc:
+                cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
+            finally:
+                # Best-effort close: a failing close() must not be misreported
+                # as a "SET TRACE OFF failed" error when the execute succeeded.
+                self._safe_close_cursor(cursor)
         try:
             connection.rollback()
         except Exception as exc:

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -120,6 +120,7 @@ class Database:
 
     @staticmethod
     def _safe_close_cursor(cursor: Any) -> None:
+        """Close a cursor on a best-effort basis, logging (not raising) failures."""
         try:
             cursor.close()
         except Exception as exc:
@@ -165,14 +166,6 @@ class Database:
                 if _is_timeout_error(exc):
                     raise self._timeout_error(exc) from exc
                 raise
-
-    @staticmethod
-    def _safe_close_cursor(cursor: Any) -> None:
-        """Close a cursor on a best-effort basis, logging (not raising) failures."""
-        try:
-            cursor.close()
-        except Exception as exc:
-            logger.debug("failed to close cursor: %s", exc)
 
     @contextmanager
     def trace_enabled(self) -> Iterator[Any]:

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -166,6 +166,50 @@ class Database:
                     raise self._timeout_error(exc) from exc
                 raise
 
+    @staticmethod
+    def _safe_close_cursor(cursor: Any) -> None:
+        """Close a cursor on a best-effort basis, logging (not raising) failures."""
+        try:
+            cursor.close()
+        except Exception as exc:
+            logger.debug("failed to close cursor: %s", exc)
+
+    @contextmanager
+    def trace_enabled(self) -> Iterator[Any]:
+        """Run statements with CUBRID ``SET TRACE ON``, guaranteeing cleanup.
+
+        Holds the connection lock across the whole ``SET TRACE ... SHOW TRACE``
+        sequence so a concurrent query cannot interleave and clobber the session
+        trace state. On exit the trace flag is turned off and any pending
+        transaction is rolled back on a best-effort basis.
+        """
+        with self.exclusive() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute("SET TRACE ON", ())
+                yield cursor
+            finally:
+                self._safe_close_cursor(cursor)
+                self._reset_trace_state(connection)
+
+    def _reset_trace_state(self, connection: Any) -> None:
+        """Best-effort cleanup of ``SET TRACE`` session state and pending transaction."""
+        cleanup_errors: list[str] = []
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute("SET TRACE OFF", ())
+            finally:
+                cursor.close()
+        except Exception as exc:
+            cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
+        try:
+            connection.rollback()
+        except Exception as exc:
+            cleanup_errors.append(f"rollback failed: {exc}")
+        if cleanup_errors:
+            logger.debug("trace cleanup: %s", "; ".join(cleanup_errors))
+
     def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         with self.cursor() as cursor:
             cursor.execute(sql, params or ())

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -192,45 +192,16 @@ def explain_query(sql: str) -> dict[str, Any]:
     # embedded second statements (e.g. "SELECT 1; DROP TABLE x") as defense in depth.
     ensure_read_only(cleaned)
 
-    db = _db()
     plan = ""
-    # Hold the connection lock across the whole SET TRACE ... SHOW TRACE sequence so a
-    # concurrent query cannot interleave and clobber the session trace state.
-    with db.exclusive() as connection:
-        try:
-            cursor = connection.cursor()
-            try:
-                cursor.execute("SET TRACE ON", ())
-                cursor.execute(cleaned, ())
-                cursor.execute("SHOW TRACE", ())
-                trace_rows = cursor.fetchall()
-                if trace_rows and trace_rows[0]:
-                    plan = str(trace_rows[0][0] or "").strip()
-            finally:
-                cursor.close()
-        finally:
-            _reset_trace_state(connection)
+    with _db().trace_enabled() as cursor:
+        cursor.execute(cleaned, ())
+        cursor.execute("SHOW TRACE", ())
+        trace_rows = cursor.fetchall()
+        if trace_rows and trace_rows[0]:
+            plan = str(trace_rows[0][0] or "").strip()
 
     return {"sql": cleaned, "plan": plan}
 
-
-def _reset_trace_state(connection: Any) -> None:
-    """Best-effort cleanup of ``SET TRACE`` session state and pending transaction."""
-    cleanup_errors: list[str] = []
-    try:
-        cursor = connection.cursor()
-        try:
-            cursor.execute("SET TRACE OFF", ())
-        finally:
-            cursor.close()
-    except Exception as exc:
-        cleanup_errors.append(f"SET TRACE OFF failed: {exc}")
-    try:
-        connection.rollback()
-    except Exception as exc:
-        cleanup_errors.append(f"rollback failed: {exc}")
-    if cleanup_errors:
-        logger.debug("explain_query cleanup: %s", "; ".join(cleanup_errors))
 
 
 @mcp.tool

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -203,7 +203,6 @@ def explain_query(sql: str) -> dict[str, Any]:
     return {"sql": cleaned, "plan": plan}
 
 
-
 @mcp.tool
 def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any]]:
     """Return ``COUNT(*)`` for each table (all user tables by default, capped)."""

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -13,6 +13,7 @@ import pytest
 
 import cubrid_mcp_server.server as server
 from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
 
 _TEST_CONFIG = Config(
@@ -107,6 +108,11 @@ class _CleanupFailingDB:
     @contextmanager
     def exclusive(self) -> Any:
         yield _CleanupFailingConn()
+
+    # Reuse the real cleanup logic so this test exercises production code.
+    _safe_close_cursor = staticmethod(Database._safe_close_cursor)
+    _reset_trace_state = Database._reset_trace_state
+    trace_enabled = Database.trace_enabled
 
 
 def test_explain_query_swallows_cleanup_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -71,6 +71,7 @@ class FakeConnection:
         self.version_error = False
         self.close_error = False
         self.cursors: list[FakeCursor] = []
+        self.rolled_back = False
 
     def get_server_version(self) -> str:
         self.server_version_calls += 1
@@ -82,6 +83,9 @@ class FakeConnection:
         cursor = FakeCursor(self._rows)
         self.cursors.append(cursor)
         return cursor
+
+    def rollback(self) -> None:
+        self.rolled_back = True
 
     def close(self) -> None:
         if self.close_error:
@@ -174,6 +178,35 @@ def test_fetch_all_returns_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     db = Database(_TEST_CONFIG)
     assert db.fetch_all("SELECT 1", None) == [(1,), (2,)]
     assert conn.cursors[0].executed == [("SELECT 1", ())]
+
+
+def test_trace_enabled_runs_and_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection(rows=[("Trace Statistics: stub",)])
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    with db.trace_enabled() as cursor:
+        cursor.execute("SELECT 1", ())
+        cursor.execute("SHOW TRACE", ())
+        assert cursor.fetchall() == [("Trace Statistics: stub",)]
+    executed = [sql for cur in conn.cursors for sql, _ in cur.executed]
+    assert "SET TRACE ON" in executed
+    assert "SET TRACE OFF" in executed
+    assert conn.rolled_back is True
+    # Every cursor opened during the trace lifecycle is closed.
+    assert all(cur.closed for cur in conn.cursors)
+
+
+def test_trace_enabled_swallows_cleanup_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BoomConn(FakeConnection):
+        def rollback(self) -> None:
+            raise RuntimeError("rollback boom")
+
+    conn = _BoomConn()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    # Cleanup failures during __exit__ are logged, not raised.
+    with db.trace_enabled() as cursor:
+        cursor.execute("SELECT 1", ())
 
 
 def test_fetch_many_truncates_across_batches(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -334,3 +367,12 @@ def test_cursor_close_error_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(conn, "cursor", _cursor)
     assert db.fetch_all("SELECT 1") == [(1,)]
+
+
+def test_safe_close_cursor_swallows_close_error() -> None:
+    class _BadCursor:
+        def close(self) -> None:
+            raise RuntimeError("close boom")
+
+    # Logged, not raised.
+    Database._safe_close_cursor(_BadCursor())

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -15,6 +15,7 @@ import pytest
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only
 
 _TEST_CONFIG = Config(
@@ -216,6 +217,11 @@ class _FakeConnDB:
 
     def connect(self) -> Any:
         return self._make_conn()
+
+    # Reuse the real trace lifecycle so refactors stay pinned to production code.
+    _safe_close_cursor = staticmethod(Database._safe_close_cursor)
+    _reset_trace_state = Database._reset_trace_state
+    trace_enabled = Database.trace_enabled
 
 
 @pytest.mark.parametrize(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ import pytest
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import UnsafeSQLError
 
 _TEST_CONFIG = Config(
@@ -180,24 +181,11 @@ class FakeConnDatabase(FakeDatabase):
 
         return _cm()
 
-    def trace_enabled(self) -> Any:
-        from contextlib import contextmanager
-
-        @contextmanager
-        def _cm() -> Any:
-            connection = self._make_conn()
-            cursor = connection.cursor()
-            try:
-                cursor.execute("SET TRACE ON", ())
-                yield cursor
-            finally:
-                cursor.close()
-                cleanup = connection.cursor()
-                cleanup.execute("SET TRACE OFF", ())
-                cleanup.close()
-                connection.rollback()
-
-        return _cm()
+    # Reuse the production trace lifecycle so this fake exercises the real
+    # SET TRACE ON/OFF + rollback cleanup path (driven by our exclusive()).
+    _safe_close_cursor = staticmethod(Database._safe_close_cursor)
+    _reset_trace_state = Database._reset_trace_state
+    trace_enabled = Database.trace_enabled
 
     def connect(self) -> Any:
         return self._make_conn()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -180,6 +180,25 @@ class FakeConnDatabase(FakeDatabase):
 
         return _cm()
 
+    def trace_enabled(self) -> Any:
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm() -> Any:
+            connection = self._make_conn()
+            cursor = connection.cursor()
+            try:
+                cursor.execute("SET TRACE ON", ())
+                yield cursor
+            finally:
+                cursor.close()
+                cleanup = connection.cursor()
+                cleanup.execute("SET TRACE OFF", ())
+                cleanup.close()
+                connection.rollback()
+
+        return _cm()
+
     def connect(self) -> Any:
         return self._make_conn()
 


### PR DESCRIPTION
## Summary
- Extracts the `SET TRACE ON ... SHOW TRACE ... SET TRACE OFF`/rollback session handling out of `server.explain_query` into a new `Database.trace_enabled()` context manager.
- Adds `Database._reset_trace_state()` (best-effort trace-off + rollback, errors logged not raised) and `Database._safe_close_cursor()` helpers.
- `explain_query` now just drives the cursor inside `with _db().trace_enabled() as cursor:` — the connection lock is held and trace state is always cleaned up in one place, closer to the connection it belongs to.

## Why
Oracle design review (#104): the trace lifecycle was leaking session-state management into the tool layer. Centralizing it in `Database` removes the duplicated cleanup path and makes the invariant (trace is always reset, transaction always rolled back) enforceable in one spot.

## Testing
- `ruff check`, `mypy --strict` clean.
- `pytest -m "not integration"` — 138 passed.
- `database.py` at 100% coverage; added direct `trace_enabled()` success + cleanup-error tests plus `_safe_close_cursor` error test. Existing `explain_query` fakes updated to reuse the real trace lifecycle.

Closes #104