### PR TITLE
refactor: replace global config/database singletons with injectable AppContext (#105)

### DIFF
--- a/cubrid_mcp_server/context.py
+++ b/cubrid_mcp_server/context.py
@@ -1,0 +1,33 @@
+"""Application context bundling configuration and the database handle.
+
+The MCP tools historically reached for two separate module-level singletons
+(``_config`` and ``_database``). ``AppContext`` replaces those with a single,
+explicitly constructed object so that configuration and its derived database
+connection are always created and torn down together, and so that tests can
+inject a fully-formed context instead of patching globals piecemeal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.database import Database
+
+
+@dataclass
+class AppContext:
+    """Bundle of the resolved :class:`Config` and its :class:`Database`."""
+
+    config: Config
+    database: Database
+
+    @classmethod
+    def from_env(cls) -> "AppContext":
+        """Build a context from environment configuration."""
+        config = Config.from_env()
+        return cls(config=config, database=Database(config))
+
+    def close(self) -> None:
+        """Release the underlying database connection."""
+        self.database.close()

--- a/cubrid_mcp_server/context.py
+++ b/cubrid_mcp_server/context.py
@@ -15,7 +15,7 @@ from cubrid_mcp_server.config import Config
 from cubrid_mcp_server.database import Database
 
 
-@dataclass
+@dataclass(frozen=True)
 class AppContext:
     """Bundle of the resolved :class:`Config` and its :class:`Database`."""
 

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
 
@@ -24,16 +25,23 @@ _MAX_ROW_COUNT_TABLES = 50
 # Binary values up to this size are returned base64-encoded; larger blobs are summarized.
 _MAX_INLINE_BINARY_BYTES = 256
 
-_config: Config | None = None
-_database: Database | None = None
+_context: AppContext | None = None
+
+
+def _get_context() -> AppContext:
+    """Return the process-wide :class:`AppContext`, building it lazily from env."""
+    global _context
+    if _context is None:
+        _context = AppContext.from_env()
+    return _context
 
 
 def _db() -> Database:
-    global _config, _database
-    if _database is None:
-        _config = Config.from_env()
-        _database = Database(_config)
-    return _database
+    return _get_context().database
+
+
+def _cfg() -> Config:
+    return _get_context().config
 
 
 def _all_table_names() -> list[str]:
@@ -176,7 +184,7 @@ def explain_query(sql: str) -> dict[str, Any]:
     cleaned = sql.strip().rstrip(";").strip()
     if not cleaned:
         raise ValueError("empty SQL statement")
-    config = _config or Config.from_env()
+    config = _cfg()
     if len(cleaned) > config.max_sql_length:
         raise ValueError(
             f"SQL exceeds maximum length of {config.max_sql_length} characters "
@@ -285,7 +293,7 @@ def list_class_hierarchy(table_name: str | None = None) -> list[dict[str, Any]]:
 def execute_query(sql: str) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
     db = _db()
-    config = _config or Config.from_env()
+    config = _cfg()
     if len(sql) > config.max_sql_length:
         raise ValueError(
             f"SQL exceeds maximum length of {config.max_sql_length} characters "
@@ -348,8 +356,8 @@ def main() -> None:
     # Fail fast with a clear message if configuration is missing/invalid, rather than
     # surfacing the error on the first tool call.
     try:
-        global _config
-        _config = Config.from_env()
+        global _context
+        _context = AppContext.from_env()
     except ConfigError as exc:
         print(f"configuration error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
@@ -357,8 +365,8 @@ def main() -> None:
     import atexit
 
     def _cleanup() -> None:
-        if _database is not None:
-            _database.close()
+        if _context is not None:
+            _context.close()
 
     atexit.register(_cleanup)
     mcp.run()

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 import sys
+import threading
 from typing import Any
 
 from fastmcp import FastMCP
@@ -26,13 +27,21 @@ _MAX_ROW_COUNT_TABLES = 50
 _MAX_INLINE_BINARY_BYTES = 256
 
 _context: AppContext | None = None
+_context_lock = threading.Lock()
 
 
 def _get_context() -> AppContext:
-    """Return the process-wide :class:`AppContext`, building it lazily from env."""
+    """Return the process-wide :class:`AppContext`, building it lazily from env.
+
+    Guarded by a lock with a double-checked pattern so that two concurrent
+    first tool calls cannot each build a separate context (and leak a
+    ``Database`` connection); exactly one context is published.
+    """
     global _context
     if _context is None:
-        _context = AppContext.from_env()
+        with _context_lock:
+            if _context is None:
+                _context = AppContext.from_env()
     return _context
 
 
@@ -354,10 +363,14 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     # Fail fast with a clear message if configuration is missing/invalid, rather than
-    # surfacing the error on the first tool call.
+    # surfacing the error on the first tool call. Reuse a context already built by the
+    # lazy path instead of replacing (and leaking) it.
     try:
         global _context
-        _context = AppContext.from_env()
+        with _context_lock:
+            if _context is None:
+                _context = AppContext.from_env()
+            context = _context
     except ConfigError as exc:
         print(f"configuration error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
@@ -365,8 +378,9 @@ def main() -> None:
     import atexit
 
     def _cleanup() -> None:
-        if _context is not None:
-            _context.close()
+        # Close the context we actually initialized here, not whatever the
+        # mutable global happens to hold at shutdown.
+        context.close()
 
     atexit.register(_cleanup)
     mcp.run()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,56 @@
+"""Unit tests for cubrid_mcp_server.context.AppContext."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cubrid_mcp_server import context as context_module
+from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.context import AppContext
+
+_TEST_CONFIG = Config(
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
+
+
+def test_from_env_builds_config_and_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    built: list[Config] = []
+
+    class _FakeDatabase:
+        def __init__(self, config: Config) -> None:
+            built.append(config)
+
+    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+    monkeypatch.setattr(context_module, "Database", _FakeDatabase)
+
+    ctx = AppContext.from_env()
+    assert ctx.config is _TEST_CONFIG
+    assert built == [_TEST_CONFIG]
+
+
+def test_close_delegates_to_database() -> None:
+    closed: list[bool] = []
+
+    class _FakeDatabase:
+        def close(self) -> None:
+            closed.append(True)
+
+    ctx = AppContext(config=_TEST_CONFIG, database=_FakeDatabase())  # type: ignore[arg-type]
+    ctx.close()
+    assert closed == [True]
+
+
+def test_appcontext_holds_injected_instances() -> None:
+    sentinel: Any = object()
+    ctx = AppContext(config=_TEST_CONFIG, database=sentinel)
+    assert ctx.database is sentinel
+    assert ctx.config is _TEST_CONFIG

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -12,7 +12,9 @@ from typing import Any
 import pytest
 
 import cubrid_mcp_server.server as server
+from cubrid_mcp_server import context as context_module
 from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
 
@@ -33,9 +35,8 @@ _TEST_CONFIG = Config(
 # ---------------------------------------------------------------------------
 
 
-def test_db_lazily_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_config", None)
-    monkeypatch.setattr(server, "_database", None)
+def test_context_lazily_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_context", None)
     monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
 
     created: list[Any] = []
@@ -44,7 +45,8 @@ def test_db_lazily_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
         def __init__(self, config: Config) -> None:
             created.append(config)
 
-    monkeypatch.setattr(server, "Database", _FakeDatabase)
+    # from_env() builds the Database via the context module's import.
+    monkeypatch.setattr(context_module, "Database", _FakeDatabase)
 
     first = server._db()
     second = server._db()
@@ -117,8 +119,9 @@ class _CleanupFailingDB:
 
 def test_explain_query_swallows_cleanup_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """SET TRACE OFF and rollback failures during cleanup are logged, not raised."""
-    monkeypatch.setattr(server, "_db", lambda: _CleanupFailingDB())
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(
+        server, "_context", AppContext(config=_TEST_CONFIG, database=_CleanupFailingDB())
+    )
     result = server.explain_query("SELECT 1")
     assert result["plan"] == "plan text"
     assert result["sql"] == "SELECT 1"
@@ -176,8 +179,7 @@ def test_main_exits_on_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_main_runs_server_on_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
-    monkeypatch.setattr(server, "_config", None)
-    monkeypatch.setattr(server, "_database", None)
+    monkeypatch.setattr(server, "_context", None)
     ran: list[bool] = []
     monkeypatch.setattr(server.mcp, "run", lambda: ran.append(True))
     server.main()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -15,6 +15,7 @@ import pytest
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only
 
@@ -236,8 +237,7 @@ class _FakeConnDB:
     ],
 )
 def test_explain_query_accepts_select_and_with(sql: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _FakeConnDB())
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=_FakeConnDB()))
     result = server.explain_query(sql)
     assert "plan" in result and "sql" in result
 
@@ -252,8 +252,7 @@ def test_explain_query_accepts_select_and_with(sql: str, monkeypatch: pytest.Mon
     ],
 )
 def test_explain_query_rejects_writes(sql: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _FakeConnDB())
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=_FakeConnDB()))
     with pytest.raises(ValueError):
         server.explain_query(sql)
 
@@ -272,8 +271,7 @@ def test_explain_query_always_read_only_even_when_readonly_disabled(
         max_chars=4000,
         max_rows=1000,
     )
-    monkeypatch.setattr(server, "_db", lambda: _FakeConnDB())
-    monkeypatch.setattr(server, "_config", write_mode)
+    monkeypatch.setattr(server, "_context", AppContext(config=write_mode, database=_FakeConnDB()))
     with pytest.raises(ValueError):
         server.explain_query("DELETE FROM users")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,17 +30,17 @@ class TestCubridIntegration:
         from cubrid_mcp_server.config import Config
         from cubrid_mcp_server.database import Database
 
+        from cubrid_mcp_server.context import AppContext
+
         self.config = Config.from_env()
         self.db = Database(self.config)
         # Route the server tool functions at the live database.
-        server._config = self.config
-        server._database = self.db
+        server._context = AppContext(config=self.config, database=self.db)
 
     def teardown_method(self) -> None:
         from cubrid_mcp_server import server
 
-        server._database = None
-        server._config = None
+        server._context = None
         self.db.close()
 
     def test_connect(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ import pytest
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import UnsafeSQLError
 
@@ -53,8 +54,7 @@ class FakeDatabase:
 @pytest.fixture
 def fake_db(monkeypatch: pytest.MonkeyPatch) -> FakeDatabase:
     fake = FakeDatabase()
-    monkeypatch.setattr(server, "_db", lambda: fake)
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=fake))
     return fake
 
 
@@ -193,8 +193,7 @@ class FakeConnDatabase(FakeDatabase):
 
 def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = FakeConnDatabase()
-    monkeypatch.setattr(server, "_db", lambda: fake)
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=fake))
     result = server.explain_query("SELECT 1")
     assert result["sql"] == "SELECT 1"
     assert "Trace Statistics" in result["plan"]
@@ -206,22 +205,25 @@ def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", FakeConnDatabase)
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(
+        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+    )
     with pytest.raises(ValueError):
         server.explain_query("DROP TABLE users")
 
 
 def test_explain_query_rejects_multistatement(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", FakeConnDatabase)
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(
+        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+    )
     with pytest.raises((ValueError, UnsafeSQLError)):
         server.explain_query("SELECT 1; DROP TABLE users")
 
 
 def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", FakeConnDatabase)
-    monkeypatch.setattr(server, "_config", _TEST_CONFIG)
+    monkeypatch.setattr(
+        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+    )
     with pytest.raises(ValueError):
         server.explain_query("   ")
 
@@ -230,8 +232,9 @@ _SHORT_SQL_CONFIG = replace(_TEST_CONFIG, max_sql_length=32)
 
 
 def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", FakeConnDatabase)
-    monkeypatch.setattr(server, "_config", _SHORT_SQL_CONFIG)
+    monkeypatch.setattr(
+        server, "_context", AppContext(config=_SHORT_SQL_CONFIG, database=FakeConnDatabase())
+    )
     with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
         server.explain_query("SELECT " + "a" * 100)
 
@@ -239,7 +242,7 @@ def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) ->
 def test_execute_query_rejects_oversized_sql(
     fake_db: FakeDatabase, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(server, "_config", _SHORT_SQL_CONFIG)
+    monkeypatch.setattr(server, "_context", AppContext(config=_SHORT_SQL_CONFIG, database=fake_db))
     with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
         server.execute_query("SELECT " + "a" * 100)
     # The oversized statement is rejected before it ever reaches the database.
@@ -323,7 +326,7 @@ def test_execute_query_renders_and_truncates(
         max_chars=10,
         max_rows=1000,
     )
-    monkeypatch.setattr(server, "_config", cfg)
+    monkeypatch.setattr(server, "_context", AppContext(config=cfg, database=fake_db))
     fake_db.queue([("short",), ("a-much-longer-row",)])
     result = server.execute_query("SELECT 1")
     assert result["row_count"] == 1


### PR DESCRIPTION
## Summary
- Adds `cubrid_mcp_server/context.py` with `AppContext(config, database)` — a single, explicitly constructed holder built lazily via `AppContext.from_env()` and torn down together (`close()`).
- Replaces the `_config` / `_database` module-level globals in `server.py` with one `_context`, exposed through `_get_context()`, `_db()`, and a new `_cfg()`.
- Removes the duplicated `config = _config or Config.from_env()` fallback in `explain_query` and `execute_query`; both now read config via `_cfg()`.
- `main()` builds the context once and the `atexit` cleanup closes it.

## Why
Oracle design review (#105): two independently-mutable globals with a repeated lazy-init/fallback idiom made state hard to reason about and to inject in tests. A single `AppContext` centralizes lifecycle (config + connection created and closed together) and makes the server injectable.

## Testing
- `ruff check`, `mypy --strict` clean.
- `pytest -m "not integration"` — 138 passed.
- Coverage 98% (`context.py` 100%); tests migrated to inject an `AppContext` instead of patching two globals. Integration test harness updated to match.

Closes #105