### PR TITLE
perf: drop per-call liveness ping, add lazy recovery + health_check tool (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 | `list_serials` | CUBRID `SERIAL` sequences with current value and bounds |
 | `list_class_hierarchy` | CUBRID `CLASS` inheritance relationships |
 | `execute_query` | Run read-only SQL with automatic output truncation |
+| `health_check` | Verify database connectivity on demand |
 
 ## Quick Start
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -72,12 +72,12 @@ class Database:
         self._lock = threading.RLock()
 
     def connect(self) -> Any:
+        # Return the cached connection without a liveness ping: pinging on every
+        # cursor acquisition adds an avoidable server round-trip to each operation.
+        # Staleness is handled lazily instead — a failed query discards the
+        # connection so the next request transparently reconnects (see ``cursor``).
         if self._connection is not None:
-            try:
-                self._connection.get_server_version()
-                return self._connection
-            except Exception:
-                self._discard_connection()
+            return self._connection
 
         try:
             self._connection = pycubrid.connect(
@@ -148,6 +148,9 @@ class Database:
                 if _is_timeout_error(exc):
                     timed_out = True
                     raise self._timeout_error(exc) from exc
+                # Lazy recovery (#106): drop the possibly-dead connection so the
+                # next request reconnects instead of pre-pinging on acquisition.
+                self._discard_connection()
                 raise DatabaseError(f"query failed: {exc}") from exc
             finally:
                 # After a timeout the connection is already discarded and the
@@ -165,6 +168,8 @@ class Database:
             except Exception as exc:
                 if _is_timeout_error(exc):
                     raise self._timeout_error(exc) from exc
+                # Lazy recovery on non-timeout failure, mirroring ``cursor``.
+                self._discard_connection()
                 raise
 
     @contextmanager
@@ -207,6 +212,23 @@ class Database:
             cleanup_errors.append(f"rollback failed: {exc}")
         if cleanup_errors:
             logger.debug("trace cleanup: %s", "; ".join(cleanup_errors))
+
+    def health_check(self) -> dict[str, Any]:
+        """Verify connectivity on demand, reconnecting lazily on failure.
+
+        Returns ``{"ok": True, "server_version": ...}`` when the connection
+        answers a liveness ping, or ``{"ok": False, "error": ...}`` otherwise.
+        This is the explicit counterpart to the per-call ping that ``connect``
+        no longer performs.
+        """
+        with self._lock:
+            try:
+                connection = self.connect()
+                version = connection.get_server_version()
+            except Exception as exc:
+                self._discard_connection()
+                return {"ok": False, "error": str(exc)}
+            return {"ok": True, "server_version": str(version)}
 
     def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         with self.cursor() as cursor:

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -320,6 +320,12 @@ def execute_query(sql: str) -> dict[str, Any]:
     }
 
 
+@mcp.tool
+def health_check() -> dict[str, Any]:
+    """Check database connectivity on demand and report server status."""
+    return _db().health_check()
+
+
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:
     output: list[list[Any]] = []
     used = 0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -123,7 +123,7 @@ def test_query_failure_triggers_lazy_reconnect(patch_connect: list[FakeConnectio
     # A failed query discards the connection so the next request reconnects.
     with pytest.raises(DatabaseError, match="query failed"):
         with db.cursor():
-            raise ValueError("boom")
+            _raise(ValueError("boom"))
     assert first.closed is True
     second = db.connect()
     assert second is not first
@@ -136,7 +136,7 @@ def test_lazy_reconnect_swallows_close_error(patch_connect: list[FakeConnection]
     first.close_error = True  # close raises during discard; must be swallowed
     with pytest.raises(DatabaseError, match="query failed"):
         with db.cursor():
-            raise ValueError("boom")
+            _raise(ValueError("boom"))
     second = db.connect()
     assert second is not first
     assert len(patch_connect) == 2

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -113,25 +113,30 @@ def test_connect_creates_and_caches_connection(patch_connect: list[FakeConnectio
     second = db.connect()
     assert first is second
     assert len(patch_connect) == 1
-    # Reuse path validates the cached connection via get_server_version.
-    assert first.server_version_calls == 1
+    # connect() no longer issues a per-call liveness ping.
+    assert first.server_version_calls == 0
 
 
-def test_connect_discards_stale_connection(patch_connect: list[FakeConnection]) -> None:
+def test_query_failure_triggers_lazy_reconnect(patch_connect: list[FakeConnection]) -> None:
     db = Database(_TEST_CONFIG)
     first = db.connect()
-    first.version_error = True  # next reuse attempt fails -> discard + reconnect
+    # A failed query discards the connection so the next request reconnects.
+    with pytest.raises(DatabaseError, match="query failed"):
+        with db.cursor():
+            raise ValueError("boom")
+    assert first.closed is True
     second = db.connect()
     assert second is not first
-    assert first.closed is True
     assert len(patch_connect) == 2
 
 
-def test_discard_connection_swallows_close_error(patch_connect: list[FakeConnection]) -> None:
+def test_lazy_reconnect_swallows_close_error(patch_connect: list[FakeConnection]) -> None:
     db = Database(_TEST_CONFIG)
     first = db.connect()
-    first.version_error = True
     first.close_error = True  # close raises during discard; must be swallowed
+    with pytest.raises(DatabaseError, match="query failed"):
+        with db.cursor():
+            raise ValueError("boom")
     second = db.connect()
     assert second is not first
     assert len(patch_connect) == 2
@@ -321,8 +326,8 @@ def test_non_timeout_error_still_wrapped_as_database_error(
     with pytest.raises(DatabaseError, match="query failed") as excinfo:
         db.fetch_all("SELECT bogus")
     assert not isinstance(excinfo.value, QueryTimeoutError)
-    # A plain query error does not invalidate the connection.
-    assert db._connection is conn
+    # Lazy recovery (#106): a query error now discards the connection too.
+    assert db._connection is None
 
 
 def test_exclusive_timeout_raises_and_discards_connection(
@@ -338,15 +343,39 @@ def test_exclusive_timeout_raises_and_discards_connection(
     assert db._connection is None
 
 
-def test_exclusive_reraises_non_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_health_check_reports_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection()
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    status = db.health_check()
+    assert status == {"ok": True, "server_version": "11.0"}
+    # health_check performs the explicit liveness ping.
+    assert conn.server_version_calls == 1
+
+
+def test_health_check_reports_failure_and_discards(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConnection()
+    conn.version_error = True
+    monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
+    db = Database(_TEST_CONFIG)
+    status = db.health_check()
+    assert status["ok"] is False
+    assert "stale connection" in status["error"]
+    # A failed ping discards the connection for lazy recovery.
+    assert conn.closed is True
+    assert db._connection is None
+
+
+def test_exclusive_discards_connection_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     conn = FakeConnection()
     monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
     db = Database(_TEST_CONFIG)
     with pytest.raises(ValueError, match="boom"):
         with db.exclusive():
             _raise(ValueError("boom"))
-    # A non-timeout error leaves the connection intact for reuse.
-    assert db._connection is conn
+    # Lazy recovery (#106): a non-timeout error drops the connection too.
+    assert conn.closed is True
+    assert db._connection is None
 
 
 def test_cursor_close_error_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -50,6 +50,9 @@ class FakeDatabase:
             return rows[:max_rows], True
         return rows, False
 
+    def health_check(self) -> dict[str, Any]:
+        return {"ok": True, "server_version": "11.0"}
+
 
 @pytest.fixture
 def fake_db(monkeypatch: pytest.MonkeyPatch) -> FakeDatabase:
@@ -70,6 +73,10 @@ def test_filter_table_names(fake_db: FakeDatabase) -> None:
 
 def test_filter_table_names_empty(fake_db: FakeDatabase) -> None:
     assert server.filter_table_names("   ") == []
+
+
+def test_health_check_tool(fake_db: FakeDatabase) -> None:
+    assert server.health_check() == {"ok": True, "server_version": "11.0"}
 
 
 def test_schema_definitions(fake_db: FakeDatabase) -> None:


### PR DESCRIPTION
## Summary
- `Database.connect()` no longer calls `get_server_version()` on every cursor acquisition — removing an avoidable server round-trip from every operation.
- Adds **lazy recovery**: when a query fails inside `cursor()` or `exclusive()`, the (possibly dead) connection is discarded so the *next* request transparently reconnects.
- Adds `Database.health_check()` plus a `health_check` MCP tool that verifies connectivity on demand and returns `{ok, server_version}` / `{ok: false, error}`.
- Documents the new tool in the README.

## Why
Oracle design review (#106): pinging on every acquisition added latency to each tool call for little benefit under the single-connection model. Lazy recovery preserves transparent reconnection while an explicit `health_check` covers on-demand verification.

## Testing
- `ruff check`, `mypy --strict` clean.
- `pytest -m "not integration"` — 140 passed; `database.py` at 100% coverage (added lazy-reconnect, cursor close-error swallow, `exclusive` recovery, and `health_check` ok/failure tests). Total coverage 98%.

Closes #106