### PR TITLE
fix: sanitize errors surfaced to the LLM client (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ For production use, also configure a read-only database user. See [`SECURITY.md`
 
 The server speaks the MCP **stdio transport**, where `stdout` carries the JSON-RPC protocol stream. Anything written to `stdout` by the server or its dependencies will corrupt that stream and break the client connection. For this reason **all logging is routed to `stderr`**, and you should keep it that way: when adding custom logging or diagnostics, never `print()` to `stdout` — use the standard `logging` module (which is configured to emit on `stderr`) or write to `stderr` explicitly. The log level defaults to `INFO`.
 
+Errors surfaced back to the LLM client are **sanitized**: only the exception category (e.g. `query failed: OperationalError`) is returned, while the full exception detail is logged to `stderr` for operators. This keeps schema details, hostnames, SQL fragments, and configuration values out of client-visible messages.
+
 
 ## Development
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -41,6 +41,16 @@ def _is_timeout_error(exc: BaseException | None) -> bool:
     return False
 
 
+def sanitize_error(exc: BaseException) -> str:
+    """Return a concise, non-sensitive description of an exception for clients.
+
+    Only the exception's class name is surfaced — never the raw message, which may
+    embed schema details, hostnames, SQL fragments, or configuration values. Full
+    detail is logged to stderr (see callers) for operator diagnostics.
+    """
+    return type(exc).__name__
+
+
 class Database:
     """Lazily opens and reuses a single pycubrid connection.
 
@@ -151,7 +161,10 @@ class Database:
                 # Lazy recovery (#106): drop the possibly-dead connection so the
                 # next request reconnects instead of pre-pinging on acquisition.
                 self._discard_connection()
-                raise DatabaseError(f"query failed: {exc}") from exc
+                # Full detail to stderr for operators; only the error category is
+                # surfaced to the client to avoid leaking schema/host/SQL/config.
+                logger.error("query failed", exc_info=exc)
+                raise DatabaseError(f"query failed: {sanitize_error(exc)}") from exc
             finally:
                 # After a timeout the connection is already discarded and the
                 # socket is dead; closing the cursor would only block again.

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -12,7 +12,7 @@ from fastmcp import FastMCP
 
 from cubrid_mcp_server.config import Config, ConfigError
 from cubrid_mcp_server.context import AppContext
-from cubrid_mcp_server.database import Database
+from cubrid_mcp_server.database import Database, sanitize_error
 from cubrid_mcp_server.safety import ensure_read_only
 
 logger = logging.getLogger(__name__)
@@ -240,7 +240,8 @@ def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any
             rows = _db().fetch_all("SELECT COUNT(*) FROM " + _quote_ident(resolved))
             results.append({"table": resolved, "row_count": int(rows[0][0]) if rows else 0})
         except Exception as exc:
-            results.append({"table": resolved, "row_count": None, "error": str(exc)})
+            logger.error("row count failed for table %s", resolved, exc_info=exc)
+            results.append({"table": resolved, "row_count": None, "error": sanitize_error(exc)})
     return results
 
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -149,7 +149,8 @@ def test_table_row_counts_rejects_too_many_tables(monkeypatch: pytest.MonkeyPatc
 def test_table_row_counts_reports_per_table_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "_db", lambda: _RowCountErrorDB())
     result = server.table_row_counts(["users"])
-    assert result == [{"table": "users", "row_count": None, "error": "count failed"}]
+    # The raw driver message is sanitized to the exception category only.
+    assert result == [{"table": "users", "row_count": None, "error": "RuntimeError"}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -18,6 +18,7 @@ from cubrid_mcp_server.database import (
     DatabaseError,
     QueryTimeoutError,
     _is_timeout_error,
+    sanitize_error,
 )
 
 _TEST_CONFIG = Config(
@@ -162,11 +163,19 @@ def test_cursor_closes_and_wraps_errors(monkeypatch: pytest.MonkeyPatch) -> None
     conn = FakeConnection()
     monkeypatch.setattr(pycubrid, "connect", lambda **_k: conn)
     db = Database(_TEST_CONFIG)
-    with pytest.raises(DatabaseError, match="query failed"):
+    with pytest.raises(DatabaseError) as excinfo:
         with db.cursor():
-            _raise(ValueError("boom"))
+            _raise(ValueError("secret schema detail public.users.ssn"))
+    # The raw message is never surfaced; only the error category is.
+    message = str(excinfo.value)
+    assert message == "query failed: ValueError"
+    assert "secret schema detail" not in message
     # Cursor is always closed, even on error.
     assert conn.cursors[0].closed is True
+
+
+def test_sanitize_error_returns_class_name_only() -> None:
+    assert sanitize_error(ValueError("host=db.internal password=hunter2")) == "ValueError"
 
 
 def test_exclusive_yields_connection(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `database.sanitize_error()` which returns only an exception's class name.
- Query failures in `Database.cursor()` now surface `query failed: <Category>` to the client and log the full exception (`exc_info`) to `stderr`.
- `table_row_counts` per-table `error` fields are sanitized the same way, with full detail logged to `stderr`.
- Documents the sanitization behavior in the README Logging section.

## Why
Oracle design review (#107): raw driver/database exception text was wrapped verbatim (`query failed: {exc}`) and returned to the LLM, potentially exposing schema details, hostnames, SQL fragments, or configuration. Sanitizing to the error category keeps client-visible messages safe while operators still get full detail on `stderr`.

## Testing
- `ruff check`, `mypy --strict` clean.
- `pytest -m "not integration"` — 136 passed; `database.py` at 100% coverage. Added tests asserting the raw message is never surfaced (`query failed: ValueError`, secret text stripped), a direct `sanitize_error` test, and an updated per-table error expectation.

Closes #107