### PR TITLE
ci: add docs-sync guard, AGENTS.md, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Brief description of changes -->
+
+## Changes
+
+<!-- List the specific changes made -->
+
+-
+
+## Type of Change
+
+<!-- Check the relevant option -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Chore (maintenance, dependencies, CI, etc.)
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have run `make check` (lint + typecheck)
+- [ ] I have run `make test` and all tests pass
+- [ ] I have added tests for new functionality (if applicable)
+- [ ] I have updated documentation for any tool/behavior/config change (or set `Docs: not needed - <reason>` / applied the `docs-not-needed` label)
+- [ ] My changes do not introduce new warnings
+
+## Related Issues
+
+<!-- Link to related issues: Closes #123, Fixes #456 -->

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,91 @@
+name: docs-sync
+
+# Fails a PR when behavior-relevant source changes land without a matching
+# documentation update. Escape hatch: add the `docs-not-needed` label OR put
+# `Docs: not needed - <reason>` in the PR body.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check behavior changes have docs updates
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_PATH: ${{ github.event_path }}
+
+          # Behavior-relevant source/config: MCP tools, server, safety, config.
+          IMPACT_GLOBS: |
+            cubrid_mcp_server/**
+            scripts/**
+            pyproject.toml
+
+          # Docs that count as "kept in sync". README documents the tool
+          # surface and configuration for this MCP server.
+          DOC_GLOBS: |
+            README*
+            CHANGELOG*
+            docs/**
+
+          # Changes that never require doc churn.
+          IGNORE_GLOBS: |
+            tests/**
+            **/tests/**
+            .github/**
+            **/*.md
+            **/*.rst
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          python - <<'PY'
+          import fnmatch, json, os, subprocess, sys
+
+          base = f"origin/{os.environ['BASE_REF']}"
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base}...HEAD"], text=True
+          ).splitlines()
+
+          def globs(name):
+              return [x.strip() for x in os.environ[name].splitlines() if x.strip()]
+
+          impact_globs = globs("IMPACT_GLOBS")
+          doc_globs = globs("DOC_GLOBS")
+          ignore_globs = globs("IGNORE_GLOBS")
+
+          def matches(path, patterns):
+              return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+          event = json.load(open(os.environ["EVENT_PATH"]))
+          pr = event.get("pull_request", {})
+          labels = {label["name"] for label in pr.get("labels", [])}
+          body = pr.get("body") or ""
+
+          skipped = "docs-not-needed" in labels or "Docs: not needed -" in body
+          doc_changed = any(matches(p, doc_globs) for p in changed)
+          relevant = [
+              p for p in changed
+              if matches(p, impact_globs) and not matches(p, ignore_globs)
+          ]
+
+          print("Changed files:")
+          for p in changed:
+              print(f"  {p}")
+
+          if relevant and not doc_changed and not skipped:
+              print("\nDocs-sync guard failed.")
+              print("Behavior-relevant files changed without a matching README/CHANGELOG/docs update.")
+              print("Either update docs, or add the `docs-not-needed` label / PR body marker:")
+              print("  Docs: not needed - <reason>")
+              print("\nRelevant files:")
+              for p in relevant:
+                  print(f"  {p}")
+              sys.exit(1)
+
+          print("\nDocs-sync guard passed.")
+          PY

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -6,13 +6,16 @@ name: docs-sync
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
 
 jobs:
   docs-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -42,7 +45,7 @@ jobs:
             **/*.md
             **/*.rst
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           python - <<'PY'
           import fnmatch, json, os, subprocess, sys
 
@@ -61,7 +64,8 @@ jobs:
           def matches(path, patterns):
               return any(fnmatch.fnmatch(path, pat) for pat in patterns)
 
-          event = json.load(open(os.environ["EVENT_PATH"]))
+          with open(os.environ["EVENT_PATH"]) as _f:
+              event = json.load(_f)
           pr = event.get("pull_request", {})
           labels = {label["name"] for label in pr.get("labels", [])}
           body = pr.get("body") or ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+Guidance for AI agents and contributors working in this repository.
+
+## Project Overview
+
+`cubrid-mcp-server` is a [Model Context Protocol](https://modelcontextprotocol.io) server for the [CUBRID](https://www.cubrid.org/) database. It lets LLM clients safely inspect schemas and run **read-only** queries via the pure-Python [pycubrid](https://pypi.org/project/pycubrid/) driver.
+
+- Package: `cubrid_mcp_server/`
+- Entry point: `python -m cubrid_mcp_server`
+- Tool surface (see `README.md`): schema inspection, index/serial/class-hierarchy listing, `explain_query`, `execute_query` (read-only), `health_check`.
+
+## Architecture
+
+```
+cubrid_mcp_server/
+├── server.py     # MCP server + tool definitions
+├── database.py   # pycubrid connection + query execution
+├── safety.py     # read-only SQL enforcement / whitelist
+├── config.py     # environment-variable configuration
+├── context.py    # request/connection context
+└── __main__.py   # module entry point
+```
+
+## Code Conventions
+
+- Python 3.10+, fully typed (`py.typed`); keep `mypy` and `ruff` clean.
+- **All logging MUST be routed to stderr.** stdout is reserved for the MCP protocol stream — never print to stdout.
+- Read-only safety is a core invariant: any change touching `safety.py` / query execution must preserve read-only enforcement and ship tests.
+
+## Development
+
+- `make install` — install in development mode
+- `make check` — ruff lint + mypy typecheck
+- `make test` — unit tests (excludes integration)
+- `make integration` — integration tests (requires a live CUBRID)
+- `make release VERSION=x.y.z` — release commit + tag
+
+## Development Workflow (cubrid-lab org standard)
+
+All non-trivial work MUST follow this cycle:
+
+1. **Oracle Design Review** — validate approach before implementation.
+2. **Implementation** — build with tests, following existing patterns.
+3. **Documentation Update** — update all affected docs (README tool table, configuration, CHANGELOG) in the same PR.
+4. **Oracle Post-Implementation Review** — review correctness, edge cases, and consistency before merging.
+
+Trivial changes (typos, single-line fixes) may skip phases 1 and 4.
+
+## Documentation definition of done
+
+Any change that affects public behavior, MCP tools, configuration/environment variables, read-only safety semantics, installation, or release semantics MUST update the matching documentation in the **same PR**. At minimum keep in sync: `README.md` (tool table + configuration) and `CHANGELOG.md`.
+
+If no documentation change is needed, state the reason explicitly in the PR body as `Docs: not needed - <reason>` or apply the `docs-not-needed` label. This is enforced by the `docs-sync` CI check.
+
+Do not mark work complete until code, tests, and documentation are consistent.
+
+## Commit Convention
+
+```
+<type>: <description>
+
+<body>
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `ci`, `style`, `test`, `refactor`
+
+## Related Projects
+
+- [pycubrid](https://github.com/cubrid-lab/pycubrid) — Pure Python DB-API 2.0 driver for CUBRID
+- [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — SQLAlchemy 2.0 dialect for CUBRID
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — Production-ready Python examples for CUBRID


### PR DESCRIPTION
## Summary

Brings this repo in line with the ecosystem-wide docs-sync rollout (#115). Adds a blocking `docs-sync` CI check plus the repo's first `AGENTS.md` and PR template.

## Changes

- `.github/workflows/docs-sync.yml` — fails when `cubrid_mcp_server/**` / `scripts/` / packaging changes without a `README`/`CHANGELOG`/`docs` touch. Ignores tests-only, CI-only, and markdown-only changes. Escape hatch: `docs-not-needed` label **or** `Docs: not needed - <reason>` in the PR body.
- `AGENTS.md` (new) — project overview, stderr-logging invariant, read-only safety invariant, org 4-phase workflow, and a "Documentation definition of done" section.
- `.github/PULL_REQUEST_TEMPLATE.md` (new) — checklist references the skip mechanism.

## Verification

- YAML parses; guard logic validated locally (same implementation as the sibling repos' guards).

## Notes

- **Do not merge** — for review only.
- `Docs: not needed - adds CI tooling + contributor docs only; no server/tool behavior change`

Closes #115