### PR TITLE
ci: auto-merge Dependabot patch/minor updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,19 @@ jobs:
         run: pip install packaging
       - name: Lint CHANGELOG.md
         run: python scripts/lint_changelog.py
+
+  ci-gate:
+    # Single required status check that aggregates every CI job so branch
+    # protection can gate merges (including Dependabot auto-merge) on one
+    # stable context instead of brittle matrix-specific job names.
+    if: always()
+    needs: [lint-and-test, lowest-direct, integration, changelog-lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "One or more required CI jobs failed."
+            exit 1
+          fi
+          echo "All required CI jobs passed."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Automatically enable auto-merge for Dependabot patch/minor updates.
+# Major updates are intentionally held for human review.
+# Auto-merge only completes once branch protection's required checks pass.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yml` enabling GitHub auto-merge for Dependabot **patch/minor** updates after required CI passes.
- **Major** updates are intentionally held for human review (workflow only acts on `semver-patch`/`semver-minor`).
- `dependabot/fetch-metadata` pinned to commit SHA `21025c7` (v2.5.0) per supply-chain best practice.
- Uses `pull_request_target` (needed so Dependabot PRs can enable auto-merge); job gated on `github.actor == 'dependabot[bot]'`, so this PR (human-authored) will not self-merge.

Reviewed with Oracle. Branch protection with a required status check will be applied after merge so `--auto` gates correctly.

Docs: not needed - internal CI automation only; no public behavior, tool, config, or install change.

Additionally adds an aggregating `ci-gate` job to `ci.yml` so branch protection can require a single stable status context instead of brittle matrix job names.