### PR TITLE
docs: add independence/non-affiliation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ export CUBRID_HOST=localhost CUBRID_USER=dba CUBRID_PASSWORD="" CUBRID_DATABASE=
 pytest -m integration
 ```
 
+## Disclaimer
+
+> This project is part of [CUBRID Lab](https://github.com/cubrid-lab), an independent open-source initiative for CUBRID developer tooling, and is not affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.
+
+
 ## License
 
 MIT (see [`LICENSE`](./LICENSE)).


### PR DESCRIPTION
## Summary

Adds a one-line **independence / non-affiliation notice** (a `## Disclaimer` section above `## License`) so first-time visitors understand this repo is part of [CUBRID Lab](https://github.com/cubrid-lab) — an independent, community-driven open-source initiative building tooling **for** CUBRID — and is **not** affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.

Mirrors the org-profile notice (cubrid-lab/.github#29). Wording reviewed with Oracle; avoids implying endorsement and avoids over-disclaiming into "unrelated to CUBRID".

Docs: not needed - README-only non-affiliation notice; no code, config, tool, or behavior change.