### PR TITLE
feat: expose schemas as MCP Resources (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Schema metadata is now exposed as read-only **MCP Resources** in addition to the existing tools: `cubrid://schema` (a whole-schema index listing every user table with its per-table resource URI) and the `cubrid://schema/{table}` template (per-table columns, primary key, and indexes, mirroring `describe_table`). Resources reuse the same read-only catalog queries — no new data access or write surface — and return `application/json`. (#124)
 - `ROADMAP.md` describing the current baseline, future direction, compatibility, and shipped history, matching the sibling repos in the Python line. (#96)
 - Repo-local `CONTRIBUTING.md` documenting the Makefile targets, the CI gates a PR must clear (ruff, mypy strict, 95% coverage floor, lowest-direct, changelog lint), and how to run the integration suite against a live CUBRID. (#94)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 | `execute_query` | Run read-only SQL with automatic output truncation |
 | `health_check` | Verify database connectivity on demand |
 
+### Resources
+
+Schema metadata is also exposed as read-only [MCP Resources](https://modelcontextprotocol.io/docs/concepts/resources), so clients can discover and read schema context without a tool call. Resources reuse the same read-only catalog queries as the tools — no additional data access or write surface.
+
+| Resource URI | Description |
+|--------------|-------------|
+| `cubrid://schema` | Whole-schema index: every user table with its per-table resource URI |
+| `cubrid://schema/{table}` | Per-table metadata (columns, primary key, indexes) — mirrors `describe_table` |
+
+Both return `application/json`. Table names in `{table}` are percent-decoded by URI-template matching; an unknown or system table produces a resource-read error, matching the `describe_table` tool.
+
 ## Quick Start
 
 ### Configure

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import sys
 import threading
@@ -345,25 +346,27 @@ _SCHEMA_INDEX_URI = "cubrid://schema"
 
 
 @mcp.resource(_SCHEMA_INDEX_URI, name="cubrid-schema-index", mime_type="application/json")
-def schema_index() -> list[dict[str, str]]:
+def schema_index() -> str:
     """Whole-schema index: every user table with its per-table resource URI."""
-    return [
-        {"name": name, "uri": f"{_SCHEMA_INDEX_URI}/{quote(name, safe='')}"}
-        for name in _all_table_names()
-    ]
+    return json.dumps(
+        [
+            {"name": name, "uri": f"{_SCHEMA_INDEX_URI}/{quote(name, safe='')}"}
+            for name in _all_table_names()
+        ]
+    )
 
 
 @mcp.resource(
     _SCHEMA_INDEX_URI + "/{table}", name="cubrid-schema-table", mime_type="application/json"
 )
-def schema_resource(table: str) -> dict[str, Any]:
+def schema_resource(table: str) -> str:
     """Per-table schema: columns, primary key, and indexes (mirrors ``describe_table``).
 
     ``table`` arrives already percent-decoded by FastMCP's URI-template matching.
     An unknown or system table raises ``ValueError`` (surfaced as a resource read
     error), matching the ``describe_table`` tool's behavior.
     """
-    return _describe_table(_resolve_table(table))
+    return json.dumps(_describe_table(_resolve_table(table)))
 
 
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import threading
 from typing import Any
+from urllib.parse import quote
 
 from fastmcp import FastMCP
 
@@ -137,7 +138,15 @@ def schema_definitions(table_name: str) -> list[dict[str, Any]]:
 @mcp.tool
 def describe_table(table_name: str) -> dict[str, Any]:
     """Return full metadata for ``table_name``: columns, primary key, and indexes."""
-    resolved = _resolve_table(table_name)
+    return _describe_table(_resolve_table(table_name))
+
+
+def _describe_table(resolved: str) -> dict[str, Any]:
+    """Build the full-metadata payload for an already-resolved table name.
+
+    Shared by the ``describe_table`` tool and the ``cubrid://schema/{table}``
+    resource so their payload shape can never drift apart.
+    """
     columns = _schema_definitions(resolved)
     indexes = _list_indexes(resolved)
     primary_key = [col["name"] for col in columns if col["primary_key"]]
@@ -325,6 +334,36 @@ def execute_query(sql: str) -> dict[str, Any]:
 def health_check() -> dict[str, Any]:
     """Check database connectivity on demand and report server status."""
     return _db().health_check()
+
+
+# Custom URI scheme for CUBRID schema resources. Registering schema metadata as
+# MCP *resources* (in addition to the existing tools) lets clients discover and
+# read schema context without a tool round-trip. These resources are strictly
+# read-only: they reuse the same catalog helpers as the tools and add no new SQL
+# path or write surface.
+_SCHEMA_INDEX_URI = "cubrid://schema"
+
+
+@mcp.resource(_SCHEMA_INDEX_URI, name="cubrid-schema-index", mime_type="application/json")
+def schema_index() -> list[dict[str, str]]:
+    """Whole-schema index: every user table with its per-table resource URI."""
+    return [
+        {"name": name, "uri": f"{_SCHEMA_INDEX_URI}/{quote(name, safe='')}"}
+        for name in _all_table_names()
+    ]
+
+
+@mcp.resource(
+    _SCHEMA_INDEX_URI + "/{table}", name="cubrid-schema-table", mime_type="application/json"
+)
+def schema_resource(table: str) -> dict[str, Any]:
+    """Per-table schema: columns, primary key, and indexes (mirrors ``describe_table``).
+
+    ``table`` arrives already percent-decoded by FastMCP's URI-template matching.
+    An unknown or system table raises ``ValueError`` (surfaced as a resource read
+    error), matching the ``describe_table`` tool's behavior.
+    """
+    return _describe_table(_resolve_table(table))
 
 
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "pytest-asyncio",
     "pytest-cov",
     "ruff==0.16.4",
     "mypy==2.3.1",
@@ -98,6 +99,7 @@ fail_under = 95
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 addopts = "--tb native -v -r fxX -p no:warnings"
 python_files = "tests/*test_*.py"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-asyncio>=0.23",
+    "pytest>=8.2",
+    "pytest-asyncio>=0.24",
     "pytest-cov",
     "ruff==0.16.4",
     "mypy==2.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
-    "pytest-asyncio",
+    "pytest-asyncio>=0.23",
     "pytest-cov",
     "ruff==0.16.4",
     "mypy==2.3.1",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -355,7 +355,7 @@ def test_render_rows_returns_first_row_when_oversized() -> None:
 
 def test_schema_index_direct(fake_db: FakeDatabase) -> None:
     fake_db.queue([("users",), ("orders",)])
-    assert server.schema_index() == [
+    assert json.loads(server.schema_index()) == [
         {"name": "users", "uri": "cubrid://schema/users"},
         {"name": "orders", "uri": "cubrid://schema/orders"},
     ]
@@ -363,7 +363,7 @@ def test_schema_index_direct(fake_db: FakeDatabase) -> None:
 
 def test_schema_index_percent_encodes_uris(fake_db: FakeDatabase) -> None:
     fake_db.queue([("my table",), ("a/b",)])
-    result = server.schema_index()
+    result = json.loads(server.schema_index())
     assert result[0]["uri"] == "cubrid://schema/my%20table"
     assert result[1]["uri"] == "cubrid://schema/a%2Fb"
 
@@ -374,7 +374,7 @@ def test_schema_resource_direct_matches_describe_table(fake_db: FakeDatabase) ->
     fake_db.queue([("id", "INTEGER", "NO", None)])
     fake_db.queue([("id",)])
     fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
-    result = server.schema_resource("users")
+    result = json.loads(server.schema_resource("users"))
     assert result["table"] == "users"
     assert result["primary_key"] == ["id"]
     assert len(result["columns"]) == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from typing import Any
 
 import pytest
+from fastmcp import Client
 
 from cubrid_mcp_server import server
 from cubrid_mcp_server.config import Config
@@ -346,3 +348,114 @@ def test_render_rows_returns_first_row_when_oversized() -> None:
     assert out["truncated"] is True
     # The single oversized value is itself truncated to the char budget.
     assert out["rows"] == [["a-ve\u2026"]]
+
+
+# --- MCP schema resources (#124) ---
+
+
+def test_schema_index_direct(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",), ("orders",)])
+    assert server.schema_index() == [
+        {"name": "users", "uri": "cubrid://schema/users"},
+        {"name": "orders", "uri": "cubrid://schema/orders"},
+    ]
+
+
+def test_schema_index_percent_encodes_uris(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("my table",), ("a/b",)])
+    result = server.schema_index()
+    assert result[0]["uri"] == "cubrid://schema/my%20table"
+    assert result[1]["uri"] == "cubrid://schema/a%2Fb"
+
+
+def test_schema_resource_direct_matches_describe_table(fake_db: FakeDatabase) -> None:
+    # _resolve_table lookup, then columns, pk, indexes (same order as describe_table).
+    fake_db.queue([("users",)])
+    fake_db.queue([("id", "INTEGER", "NO", None)])
+    fake_db.queue([("id",)])
+    fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
+    result = server.schema_resource("users")
+    assert result["table"] == "users"
+    assert result["primary_key"] == ["id"]
+    assert len(result["columns"]) == 1
+    assert len(result["indexes"]) == 1
+
+
+def test_schema_resource_unknown_table_raises(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])  # _resolve_table lookup: 'nope' not present
+    with pytest.raises(ValueError, match="unknown table"):
+        server.schema_resource("nope")
+
+
+async def test_schema_resources_listed_via_protocol(fake_db: FakeDatabase) -> None:
+    async with Client(server.mcp) as client:
+        resources = await client.list_resources()
+        templates = await client.list_resource_templates()
+    assert "cubrid://schema" in {str(r.uri) for r in resources}
+    assert "cubrid://schema/{table}" in {t.uriTemplate for t in templates}
+
+
+async def test_read_schema_index_resource(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",), ("orders",)])
+    async with Client(server.mcp) as client:
+        contents = await client.read_resource("cubrid://schema")
+    assert contents[0].mimeType == "application/json"
+    payload = json.loads(contents[0].text)
+    assert payload == [
+        {"name": "users", "uri": "cubrid://schema/users"},
+        {"name": "orders", "uri": "cubrid://schema/orders"},
+    ]
+
+
+async def test_read_schema_table_resource_matches_describe_table(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])
+    fake_db.queue([("id", "INTEGER", "NO", None)])
+    fake_db.queue([("id",)])
+    fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
+    async with Client(server.mcp) as client:
+        contents = await client.read_resource("cubrid://schema/users")
+    payload = json.loads(contents[0].text)
+    assert payload == {
+        "table": "users",
+        "columns": [
+            {
+                "name": "id",
+                "type": "INTEGER",
+                "nullable": False,
+                "default": None,
+                "primary_key": True,
+            }
+        ],
+        "primary_key": ["id"],
+        "indexes": [
+            {
+                "name": "pk_users",
+                "unique": True,
+                "primary_key": True,
+                "foreign_key": False,
+                "reverse": False,
+                "key_count": 1,
+                "columns": [{"name": "id", "order": 0, "asc_desc": "ASC"}],
+            }
+        ],
+    }
+
+
+async def test_read_unknown_table_resource_fails(fake_db: FakeDatabase) -> None:
+    fake_db.queue([("users",)])  # 'nope' not present
+    async with Client(server.mcp) as client:
+        with pytest.raises(Exception):
+            await client.read_resource("cubrid://schema/nope")
+
+
+async def test_read_schema_table_resource_percent_decodes_name(fake_db: FakeDatabase) -> None:
+    # An encoded '/' in the URI must round-trip to a literal 'a/b' table name.
+    fake_db.queue([("a/b",)])  # _resolve_table lookup
+    fake_db.queue([("id", "INTEGER", "NO", None)])
+    fake_db.queue([("id",)])
+    fake_db.queue([])  # no indexes
+    async with Client(server.mcp) as client:
+        contents = await client.read_resource("cubrid://schema/a%2Fb")
+    payload = json.loads(contents[0].text)
+    assert payload["table"] == "a/b"
+    assert payload["columns"][0]["name"] == "id"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -369,16 +369,19 @@ def test_schema_index_percent_encodes_uris(fake_db: FakeDatabase) -> None:
 
 
 def test_schema_resource_direct_matches_describe_table(fake_db: FakeDatabase) -> None:
-    # _resolve_table lookup, then columns, pk, indexes (same order as describe_table).
+    # schema_resource must return exactly what describe_table produces.
     fake_db.queue([("users",)])
     fake_db.queue([("id", "INTEGER", "NO", None)])
     fake_db.queue([("id",)])
     fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
-    result = json.loads(server.schema_resource("users"))
-    assert result["table"] == "users"
-    assert result["primary_key"] == ["id"]
-    assert len(result["columns"]) == 1
-    assert len(result["indexes"]) == 1
+    resource_payload = json.loads(server.schema_resource("users"))
+    # Re-queue the identical batches for the describe_table call.
+    fake_db.queue([("users",)])
+    fake_db.queue([("id", "INTEGER", "NO", None)])
+    fake_db.queue([("id",)])
+    fake_db.queue([("pk_users", "YES", "YES", "NO", "NO", 1, "id", 0, "ASC")])
+    tool_payload = server.describe_table("users")
+    assert resource_payload == tool_payload
 
 
 def test_schema_resource_unknown_table_raises(fake_db: FakeDatabase) -> None:
@@ -444,7 +447,7 @@ async def test_read_schema_table_resource_matches_describe_table(fake_db: FakeDa
 async def test_read_unknown_table_resource_fails(fake_db: FakeDatabase) -> None:
     fake_db.queue([("users",)])  # 'nope' not present
     async with Client(server.mcp) as client:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="unknown table"):
             await client.read_resource("cubrid://schema/nope")
 
 


### PR DESCRIPTION
## Summary

Closes #124 (part of the v0.3.x epic #23). Exposes CUBRID schema metadata as read-only **MCP Resources** in addition to the existing tools, so clients can discover and read schema context without a tool round-trip.

## Resources

| URI | Description |
|-----|-------------|
| `cubrid://schema` | Whole-schema index: every user table with its per-table resource URI (percent-encoded) |
| `cubrid://schema/{table}` | Per-table columns, primary key, and indexes — mirrors the `describe_table` tool |

Both return `application/json`.

## Design

- **No new data access or write surface.** Resources reuse the exact same read-only catalog helpers (`_all_table_names`, `_resolve_table`, `_schema_definitions`, `_list_indexes`) as the existing tools.
- A shared `_describe_table(resolved)` helper now backs **both** the `describe_table` tool and the `cubrid://schema/{table}` resource, so their payloads cannot drift.
- The index emits per-table URIs percent-encoded via `quote(name, safe="")`; FastMCP percent-decodes `{table}` before the handler runs (round-trip verified for `/`).
- Unknown/system tables raise `ValueError` → surfaced as a resource-read error, matching tool semantics.

## Tests

- Direct-call tests: index shape, percent-encoding (`my table`→`my%20table`, `a/b`→`a%2Fb`), per-table payload, unknown-table raises.
- In-process `fastmcp.Client` protocol tests: `list_resources`, `list_resource_templates`, read index, read table (full payload equality vs `describe_table`), encoded-name round-trip, unknown-table read fails.
- Full suite: **176 passed, 14 skipped**.
- Declares `pytest-asyncio` (previously only installed locally, not in dev deps) and sets `asyncio_mode = "auto"` for the async Client tests.

## Docs

- `README.md` — new "Resources" section + table.
- `CHANGELOG.md` — `[Unreleased] / ### Added` entry.

## Review

Followed the cubrid-lab 4-phase workflow. Oracle **design review** (APPROVE WITH CHANGES — index returns `{name, uri}`, percent-encoding, shared helper: all incorporated) and **post-implementation review** (APPROVE WITH NITS — encoded round-trip test, full-equality assertion, pyproject indentation: all addressed).