### PR TITLE
feat: multi-database connection management (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ROADMAP.md` describing the current baseline, future direction, compatibility, and shipped history, matching the sibling repos in the Python line. (#96)
+- Multi-database connection management: configure additional named connections via `CUBRID_CONNECTIONS` plus `CUBRID_<NAME>_*` variables, and target them per call with the new optional `connection` argument on every tool. The bare `CUBRID_*` variables continue to define the reserved `default` connection, so single-database setups are unchanged. Each connection has its own lock, read-only enforcement, and stale-connection lifecycle. (#126)
 - Repo-local `CONTRIBUTING.md` documenting the Makefile targets, the CI gates a PR must clear (ruff, mypy strict, 95% coverage floor, lowest-direct, changelog lint), and how to run the integration suite against a live CUBRID. (#94)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -42,6 +42,49 @@ Optional settings:
 | `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
 | `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
 
+### Multiple connections
+
+By default the bare `CUBRID_*` variables define a single connection named `default`.
+You can serve additional CUBRID databases from the same process by listing extra
+connection names in `CUBRID_CONNECTIONS` (comma-separated) and providing
+`CUBRID_<NAME>_*` variables for each. Every tool accepts an optional `connection`
+argument selecting which connection to target; omitting it (or passing `default`)
+uses the bare-variable connection, so existing single-database setups are unchanged.
+
+```bash
+# Default connection (unchanged)
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+
+# Additional named connections
+export CUBRID_CONNECTIONS=reporting,analytics
+
+export CUBRID_REPORTING_HOST=reporting-db
+export CUBRID_REPORTING_USER=readonly_user
+export CUBRID_REPORTING_PASSWORD=secret
+export CUBRID_REPORTING_DATABASE=reports
+export CUBRID_REPORTING_MCP_MAX_ROWS=500   # optional per-connection tuning
+
+export CUBRID_ANALYTICS_HOST=analytics-db
+export CUBRID_ANALYTICS_USER=readonly_user
+export CUBRID_ANALYTICS_PASSWORD=secret
+export CUBRID_ANALYTICS_DATABASE=analytics
+```
+
+Notes:
+
+- Connection names must match `[A-Za-z0-9_]+` and are matched case-insensitively.
+- `default` is reserved (it always comes from the bare `CUBRID_*` variables) and
+  cannot appear in `CUBRID_CONNECTIONS`.
+- For a named connection `<NAME>`, connection fields live at `CUBRID_<NAME>_HOST`
+  etc. and the optional MCP tuning knobs at `CUBRID_<NAME>_MCP_*` (same suffixes as
+  the global ones). Named connections do **not** inherit values from the bare vars.
+- Selecting an unknown connection returns a clear error listing the available names.
+- Each connection has its own read-only enforcement, so a named connection can set
+  `CUBRID_<NAME>_MCP_READONLY` independently of the default.
+
 ### Run
 
 > **Note:** The package is not yet published to PyPI. Until the first release lands, install and run it from source (see [Development](#development)); the `uvx`/`pipx` commands below will work once the package is available on PyPI.

--- a/cubrid_mcp_server/config.py
+++ b/cubrid_mcp_server/config.py
@@ -3,7 +3,15 @@
 from __future__ import annotations
 
 import os
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+
+#: Default name of the connection built from the bare ``CUBRID_*`` variables.
+DEFAULT_CONNECTION = "default"
+
+#: Connection names must be simple identifiers so they map cleanly onto env vars.
+_NAME_PATTERN = re.compile(r"[A-Za-z0-9_]+")
 
 
 class ConfigError(RuntimeError):
@@ -25,75 +33,130 @@ class Config:
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Config":
+        """Build the default connection config from the bare ``CUBRID_*`` variables."""
         source = env if env is not None else os.environ
-        try:
-            host = source["CUBRID_HOST"]
-            user = source["CUBRID_USER"]
-            password = source["CUBRID_PASSWORD"]
-            database = source["CUBRID_DATABASE"]
-        except KeyError as missing:
-            raise ConfigError(f"missing required environment variable: {missing.args[0]}") from None
+        return _parse_config(source, "CUBRID_")
 
-        port_raw = source.get("CUBRID_PORT", "33000")
-        try:
-            port = int(port_raw)
-        except ValueError as exc:
-            raise ConfigError(f"CUBRID_PORT must be an integer, got {port_raw!r}") from exc
 
-        readonly = _parse_bool(source.get("CUBRID_MCP_READONLY", "1"))
+def _parse_config(source: Mapping[str, str], prefix: str) -> Config:
+    """Parse a single connection's :class:`Config` from ``source`` using ``prefix``.
 
-        max_chars_raw = source.get("CUBRID_MCP_MAX_CHARS", "4000")
-        try:
-            max_chars = int(max_chars_raw)
-        except ValueError as exc:
-            raise ConfigError(
-                f"CUBRID_MCP_MAX_CHARS must be an integer, got {max_chars_raw!r}"
-            ) from exc
-        if max_chars <= 0:
-            raise ConfigError("CUBRID_MCP_MAX_CHARS must be positive")
+    ``prefix`` is the environment-variable prefix for this connection: ``"CUBRID_"``
+    for the default connection and ``"CUBRID_<NAME>_"`` for a named one. Connection
+    fields live at ``{prefix}HOST`` etc.; MCP tuning knobs live at ``{prefix}MCP_*``.
+    """
+    mcp_prefix = f"{prefix}MCP_"
+    try:
+        host = source[f"{prefix}HOST"]
+        user = source[f"{prefix}USER"]
+        password = source[f"{prefix}PASSWORD"]
+        database = source[f"{prefix}DATABASE"]
+    except KeyError as missing:
+        raise ConfigError(f"missing required environment variable: {missing.args[0]}") from None
 
-        max_rows_raw = source.get("CUBRID_MCP_MAX_ROWS", "1000")
-        try:
-            max_rows = int(max_rows_raw)
-        except ValueError as exc:
-            raise ConfigError(
-                f"CUBRID_MCP_MAX_ROWS must be an integer, got {max_rows_raw!r}"
-            ) from exc
-        if max_rows <= 0:
-            raise ConfigError("CUBRID_MCP_MAX_ROWS must be positive")
+    port_raw = source.get(f"{prefix}PORT", "33000")
+    try:
+        port = int(port_raw)
+    except ValueError as exc:
+        raise ConfigError(f"{prefix}PORT must be an integer, got {port_raw!r}") from exc
 
-        max_sql_length_raw = source.get("CUBRID_MCP_MAX_SQL_LENGTH", "65536")
-        try:
-            max_sql_length = int(max_sql_length_raw)
-        except ValueError as exc:
-            raise ConfigError(
-                f"CUBRID_MCP_MAX_SQL_LENGTH must be an integer, got {max_sql_length_raw!r}"
-            ) from exc
-        if max_sql_length <= 0:
-            raise ConfigError("CUBRID_MCP_MAX_SQL_LENGTH must be positive")
+    readonly = _parse_bool(source.get(f"{mcp_prefix}READONLY", "1"))
 
-        query_timeout_raw = source.get("CUBRID_MCP_QUERY_TIMEOUT", "30")
-        try:
-            query_timeout = float(query_timeout_raw)
-        except ValueError as exc:
-            raise ConfigError(
-                f"CUBRID_MCP_QUERY_TIMEOUT must be a number, got {query_timeout_raw!r}"
-            ) from exc
-        if query_timeout <= 0:
-            raise ConfigError("CUBRID_MCP_QUERY_TIMEOUT must be positive")
+    max_chars = _parse_positive_int(source, f"{mcp_prefix}MAX_CHARS", "4000")
+    max_rows = _parse_positive_int(source, f"{mcp_prefix}MAX_ROWS", "1000")
+    max_sql_length = _parse_positive_int(source, f"{mcp_prefix}MAX_SQL_LENGTH", "65536")
 
-        return cls(
-            host=host,
-            port=port,
-            user=user,
-            password=password,
-            database=database,
-            readonly=readonly,
-            max_chars=max_chars,
-            max_rows=max_rows,
-            max_sql_length=max_sql_length,
-            query_timeout=query_timeout,
+    query_timeout_raw = source.get(f"{mcp_prefix}QUERY_TIMEOUT", "30")
+    try:
+        query_timeout = float(query_timeout_raw)
+    except ValueError as exc:
+        raise ConfigError(
+            f"{mcp_prefix}QUERY_TIMEOUT must be a number, got {query_timeout_raw!r}"
+        ) from exc
+    if query_timeout <= 0:
+        raise ConfigError(f"{mcp_prefix}QUERY_TIMEOUT must be positive")
+
+    return Config(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=database,
+        readonly=readonly,
+        max_chars=max_chars,
+        max_rows=max_rows,
+        max_sql_length=max_sql_length,
+        query_timeout=query_timeout,
+    )
+
+
+def _parse_positive_int(source: Mapping[str, str], key: str, default: str) -> int:
+    raw = source.get(key, default)
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ConfigError(f"{key} must be an integer, got {raw!r}") from exc
+    if value <= 0:
+        raise ConfigError(f"{key} must be positive")
+    return value
+
+
+@dataclass(frozen=True)
+class ConnectionRegistry:
+    """A named set of connection :class:`Config` objects with a default.
+
+    The default connection always comes from the bare ``CUBRID_*`` variables, so a
+    deployment that sets no ``CUBRID_CONNECTIONS`` behaves exactly as it did before
+    multi-connection support existed. Additional named connections are read from
+    ``CUBRID_<NAME>_*`` variables. Connection names are matched case-insensitively.
+    """
+
+    configs: Mapping[str, Config]
+    default_name: str = DEFAULT_CONNECTION
+
+    def config_for(self, connection: str | None = None) -> Config:
+        """Return the config for ``connection`` (the default when ``None``/empty).
+
+        Raises :class:`ConfigError` naming the available connections when the
+        requested name is unknown, so the message is safe to surface to clients.
+        """
+        name = (
+            connection.strip().lower() if connection and connection.strip() else self.default_name
         )
+        try:
+            return self.configs[name]
+        except KeyError:
+            available = ", ".join(sorted(self.configs))
+            raise ConfigError(
+                f"unknown connection {name!r}. Available connections: {available}"
+            ) from None
+
+    @property
+    def names(self) -> list[str]:
+        return sorted(self.configs)
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "ConnectionRegistry":
+        source = env if env is not None else os.environ
+        configs: dict[str, Config] = {DEFAULT_CONNECTION: _parse_config(source, "CUBRID_")}
+
+        raw = source.get("CUBRID_CONNECTIONS", "").strip()
+        if raw:
+            for original in (part.strip() for part in raw.split(",")):
+                if not original:
+                    continue
+                if not _NAME_PATTERN.fullmatch(original):
+                    raise ConfigError(
+                        f"invalid connection name {original!r}: names must match [A-Za-z0-9_]+"
+                    )
+                name = original.lower()
+                if name == DEFAULT_CONNECTION:
+                    raise ConfigError("connection name 'default' is reserved")
+                if name in configs:
+                    raise ConfigError(f"duplicate connection name {original!r}")
+                configs[name] = _parse_config(source, f"CUBRID_{original.upper()}_")
+
+        return cls(configs=configs)
 
 
 def _parse_bool(value: str) -> bool:

--- a/cubrid_mcp_server/context.py
+++ b/cubrid_mcp_server/context.py
@@ -1,33 +1,87 @@
-"""Application context bundling configuration and the database handle.
+"""Application context bundling configuration and the database handles.
 
 The MCP tools historically reached for two separate module-level singletons
 (``_config`` and ``_database``). ``AppContext`` replaces those with a single,
 explicitly constructed object so that configuration and its derived database
-connection are always created and torn down together, and so that tests can
+connections are always created and torn down together, and so that tests can
 inject a fully-formed context instead of patching globals piecemeal.
+
+With multi-connection support (issue #126) the context owns a *registry* of
+named connections. Each named connection has its own :class:`Config` and its own
+:class:`Database` instance (hence its own lock and stale-connection lifecycle);
+there is no shared connection state. A deployment that configures only the bare
+``CUBRID_*`` variables gets a single ``default`` connection and behaves exactly
+as it did before.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
-from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.config import (
+    DEFAULT_CONNECTION,
+    Config,
+    ConnectionRegistry,
+)
 from cubrid_mcp_server.database import Database
 
 
 @dataclass(frozen=True)
 class AppContext:
-    """Bundle of the resolved :class:`Config` and its :class:`Database`."""
+    """Bundle of the resolved :class:`ConnectionRegistry` and its databases."""
 
-    config: Config
-    database: Database
+    registry: ConnectionRegistry
+    databases: Mapping[str, Database]
 
     @classmethod
     def from_env(cls) -> "AppContext":
-        """Build a context from environment configuration."""
-        config = Config.from_env()
-        return cls(config=config, database=Database(config))
+        """Build a context and its databases from environment configuration."""
+        registry = ConnectionRegistry.from_env()
+        databases = {name: Database(config) for name, config in registry.configs.items()}
+        return cls(registry=registry, databases=databases)
+
+    @classmethod
+    def single(
+        cls,
+        config: Config,
+        database: Database,
+        name: str = DEFAULT_CONNECTION,
+    ) -> "AppContext":
+        """Build a single-connection context (convenience for tests and callers)."""
+        registry = ConnectionRegistry(configs={name: config}, default_name=name)
+        return cls(registry=registry, databases={name: database})
+
+    def config_for(self, connection: str | None = None) -> Config:
+        """Return the :class:`Config` for ``connection`` (default when ``None``)."""
+        return self.registry.config_for(connection)
+
+    def database_for(self, connection: str | None = None) -> Database:
+        """Return the :class:`Database` for ``connection`` (default when ``None``).
+
+        Validates the name through the registry first so an unknown connection
+        raises the same clear, client-safe error as :meth:`config_for`.
+        """
+        self.registry.config_for(connection)
+        name = (
+            connection.strip().lower()
+            if connection and connection.strip()
+            else self.registry.default_name
+        )
+        return self.databases[name]
 
     def close(self) -> None:
-        """Release the underlying database connection."""
-        self.database.close()
+        """Close every database connection, best-effort.
+
+        Every database is closed even if an earlier one raises; the first error
+        (if any) is re-raised once all databases have been given a chance to close.
+        """
+        first_error: Exception | None = None
+        for database in self.databases.values():
+            try:
+                database.close()
+            except Exception as exc:  # noqa: BLE001 - close all before re-raising
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -45,17 +45,17 @@ def _get_context() -> AppContext:
     return _context
 
 
-def _db() -> Database:
-    return _get_context().database
+def _db(connection: str | None = None) -> Database:
+    return _get_context().database_for(connection)
 
 
-def _cfg() -> Config:
-    return _get_context().config
+def _cfg(connection: str | None = None) -> Config:
+    return _get_context().config_for(connection)
 
 
-def _all_table_names() -> list[str]:
+def _all_table_names(connection: str | None = None) -> list[str]:
     """Internal helper: list every user table (excludes system classes and views)."""
-    rows = _db().fetch_all(
+    rows = _db(connection).fetch_all(
         "SELECT class_name FROM db_class "
         "WHERE is_system_class='NO' AND class_type='CLASS' "
         "ORDER BY class_name"
@@ -63,7 +63,7 @@ def _all_table_names() -> list[str]:
     return [row[0] for row in rows]
 
 
-def _resolve_table(table_name: str) -> str:
+def _resolve_table(table_name: str, connection: str | None = None) -> str:
     """Resolve ``table_name`` to its canonical stored name (case-insensitive).
 
     Raises :class:`ValueError` if no matching user table exists. This both prevents
@@ -73,29 +73,29 @@ def _resolve_table(table_name: str) -> str:
     needle = table_name.strip().lower()
     if not needle:
         raise ValueError("table name must not be empty")
-    for name in _all_table_names():
+    for name in _all_table_names(connection):
         if name.lower() == needle:
             return name
     raise ValueError(f"unknown table: {table_name!r}")
 
 
 @mcp.tool
-def all_table_names() -> list[str]:
+def all_table_names(connection: str | None = None) -> list[str]:
     """Return every user table in the connected CUBRID database."""
-    return _all_table_names()
+    return _all_table_names(connection)
 
 
 @mcp.tool
-def filter_table_names(substring: str) -> list[str]:
+def filter_table_names(substring: str, connection: str | None = None) -> list[str]:
     """Return user tables whose name contains ``substring`` (case-insensitive)."""
     needle = substring.strip().lower()
     if not needle:
         return []
-    return [name for name in _all_table_names() if needle in name.lower()]
+    return [name for name in _all_table_names(connection) if needle in name.lower()]
 
 
-def _schema_definitions(table_name: str) -> list[dict[str, Any]]:
-    rows = _db().fetch_all(
+def _schema_definitions(table_name: str, connection: str | None = None) -> list[dict[str, Any]]:
+    rows = _db(connection).fetch_all(
         """
         SELECT a.attr_name, a.data_type, a.is_nullable, a.default_value
         FROM db_attribute a
@@ -104,7 +104,7 @@ def _schema_definitions(table_name: str) -> list[dict[str, Any]]:
         """,
         (table_name,),
     )
-    pk_rows = _db().fetch_all(
+    pk_rows = _db(connection).fetch_all(
         """
         SELECT k.key_attr_name
         FROM db_index i, db_index_key k
@@ -129,17 +129,17 @@ def _schema_definitions(table_name: str) -> list[dict[str, Any]]:
 
 
 @mcp.tool
-def schema_definitions(table_name: str) -> list[dict[str, Any]]:
+def schema_definitions(table_name: str, connection: str | None = None) -> list[dict[str, Any]]:
     """Return column metadata for ``table_name``: name, type, nullability, default, PK flag."""
-    return _schema_definitions(_resolve_table(table_name))
+    return _schema_definitions(_resolve_table(table_name, connection), connection)
 
 
 @mcp.tool
-def describe_table(table_name: str) -> dict[str, Any]:
+def describe_table(table_name: str, connection: str | None = None) -> dict[str, Any]:
     """Return full metadata for ``table_name``: columns, primary key, and indexes."""
-    resolved = _resolve_table(table_name)
-    columns = _schema_definitions(resolved)
-    indexes = _list_indexes(resolved)
+    resolved = _resolve_table(table_name, connection)
+    columns = _schema_definitions(resolved, connection)
+    indexes = _list_indexes(resolved, connection)
     primary_key = [col["name"] for col in columns if col["primary_key"]]
     return {
         "table": resolved,
@@ -149,8 +149,8 @@ def describe_table(table_name: str) -> dict[str, Any]:
     }
 
 
-def _list_indexes(table_name: str) -> list[dict[str, Any]]:
-    rows = _db().fetch_all(
+def _list_indexes(table_name: str, connection: str | None = None) -> list[dict[str, Any]]:
+    rows = _db(connection).fetch_all(
         """
         SELECT i.index_name, i.is_unique, i.is_primary_key, i.is_foreign_key,
                i.is_reverse, i.key_count, k.key_attr_name, k.key_order, k.asc_desc
@@ -182,18 +182,18 @@ def _list_indexes(table_name: str) -> list[dict[str, Any]]:
 
 
 @mcp.tool
-def list_indexes(table_name: str) -> list[dict[str, Any]]:
+def list_indexes(table_name: str, connection: str | None = None) -> list[dict[str, Any]]:
     """Return indexes for ``table_name`` with their key columns and flags."""
-    return _list_indexes(_resolve_table(table_name))
+    return _list_indexes(_resolve_table(table_name, connection), connection)
 
 
 @mcp.tool
-def explain_query(sql: str) -> dict[str, Any]:
+def explain_query(sql: str, connection: str | None = None) -> dict[str, Any]:
     """Return CUBRID's execution plan/trace for a ``SELECT`` or ``WITH`` statement."""
     cleaned = sql.strip().rstrip(";").strip()
     if not cleaned:
         raise ValueError("empty SQL statement")
-    config = _cfg()
+    config = _cfg(connection)
     if len(cleaned) > config.max_sql_length:
         raise ValueError(
             f"SQL exceeds maximum length of {config.max_sql_length} characters "
@@ -210,7 +210,7 @@ def explain_query(sql: str) -> dict[str, Any]:
     ensure_read_only(cleaned)
 
     plan = ""
-    with _db().trace_enabled() as cursor:
+    with _db(connection).trace_enabled() as cursor:
         cursor.execute(cleaned, ())
         cursor.execute("SHOW TRACE", ())
         trace_rows = cursor.fetchall()
@@ -221,9 +221,11 @@ def explain_query(sql: str) -> dict[str, Any]:
 
 
 @mcp.tool
-def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any]]:
+def table_row_counts(
+    table_names: list[str] | None = None, connection: str | None = None
+) -> list[dict[str, Any]]:
     """Return ``COUNT(*)`` for each table (all user tables by default, capped)."""
-    known = _all_table_names()
+    known = _all_table_names(connection)
     known_lower = {name.lower(): name for name in known}
     targets = table_names if table_names else sorted(known)
     if len(targets) > _MAX_ROW_COUNT_TABLES:
@@ -237,7 +239,7 @@ def table_row_counts(table_names: list[str] | None = None) -> list[dict[str, Any
             results.append({"table": name, "row_count": None, "error": "unknown table"})
             continue
         try:
-            rows = _db().fetch_all("SELECT COUNT(*) FROM " + _quote_ident(resolved))
+            rows = _db(connection).fetch_all("SELECT COUNT(*) FROM " + _quote_ident(resolved))
             results.append({"table": resolved, "row_count": int(rows[0][0]) if rows else 0})
         except Exception as exc:
             logger.error("row count failed for table %s", resolved, exc_info=exc)
@@ -251,9 +253,9 @@ def _quote_ident(name: str) -> str:
 
 
 @mcp.tool
-def list_serials() -> list[dict[str, Any]]:
+def list_serials(connection: str | None = None) -> list[dict[str, Any]]:
     """Return CUBRID SERIAL sequences with current value, increment, and bounds."""
-    rows = _db().fetch_all(
+    rows = _db(connection).fetch_all(
         """
         SELECT name, current_val, increment_val, max_val, min_val,
                cyclic, started, class_name, att_name, cached_num, comment
@@ -280,16 +282,18 @@ def list_serials() -> list[dict[str, Any]]:
 
 
 @mcp.tool
-def list_class_hierarchy(table_name: str | None = None) -> list[dict[str, Any]]:
+def list_class_hierarchy(
+    table_name: str | None = None, connection: str | None = None
+) -> list[dict[str, Any]]:
     """Return CUBRID CLASS inheritance relationships (all classes or one class)."""
     if table_name:
-        rows = _db().fetch_all(
+        rows = _db(connection).fetch_all(
             "SELECT class_name, super_class_name FROM db_direct_super_class "
             "WHERE class_name = ? ORDER BY super_class_name",
             (table_name,),
         )
     else:
-        rows = _db().fetch_all(
+        rows = _db(connection).fetch_all(
             "SELECT class_name, super_class_name FROM db_direct_super_class "
             "ORDER BY class_name, super_class_name"
         )
@@ -300,10 +304,10 @@ def list_class_hierarchy(table_name: str | None = None) -> list[dict[str, Any]]:
 
 
 @mcp.tool
-def execute_query(sql: str) -> dict[str, Any]:
+def execute_query(sql: str, connection: str | None = None) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
-    db = _db()
-    config = _cfg()
+    db = _db(connection)
+    config = _cfg(connection)
     if len(sql) > config.max_sql_length:
         raise ValueError(
             f"SQL exceeds maximum length of {config.max_sql_length} characters "
@@ -322,9 +326,9 @@ def execute_query(sql: str) -> dict[str, Any]:
 
 
 @mcp.tool
-def health_check() -> dict[str, Any]:
+def health_check(connection: str | None = None) -> dict[str, Any]:
     """Check database connectivity on demand and report server status."""
-    return _db().health_check()
+    return _db(connection).health_check()
 
 
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.config import Config, ConfigError, ConnectionRegistry
 
 
 BASE_ENV = {
@@ -101,3 +101,104 @@ def test_from_env_invalid_query_timeout() -> None:
 def test_password_not_in_repr() -> None:
     cfg = Config.from_env(BASE_ENV)
     assert "secret" not in repr(cfg)
+
+
+def test_registry_default_only_when_no_connections() -> None:
+    registry = ConnectionRegistry.from_env(BASE_ENV)
+    assert registry.names == ["default"]
+    assert registry.config_for().database == "demodb"
+    # None/empty selector resolves to the default connection.
+    assert registry.config_for(None) is registry.config_for()
+    assert registry.config_for("   ") is registry.config_for()
+
+
+def test_registry_empty_connections_behaves_like_unset() -> None:
+    registry = ConnectionRegistry.from_env(BASE_ENV | {"CUBRID_CONNECTIONS": "  "})
+    assert registry.names == ["default"]
+
+
+def test_registry_missing_default_vars_still_fails() -> None:
+    env = {k: v for k, v in BASE_ENV.items() if k != "CUBRID_HOST"}
+    with pytest.raises(ConfigError, match="CUBRID_HOST"):
+        ConnectionRegistry.from_env(env)
+
+
+def test_registry_parses_named_connection() -> None:
+    env = BASE_ENV | {
+        "CUBRID_CONNECTIONS": "reporting",
+        "CUBRID_REPORTING_HOST": "reporting-db",
+        "CUBRID_REPORTING_USER": "ru",
+        "CUBRID_REPORTING_PASSWORD": "rp",
+        "CUBRID_REPORTING_DATABASE": "reports",
+        "CUBRID_REPORTING_MCP_MAX_ROWS": "500",
+    }
+    registry = ConnectionRegistry.from_env(env)
+    assert registry.names == ["default", "reporting"]
+    reporting = registry.config_for("reporting")
+    assert reporting.host == "reporting-db"
+    assert reporting.database == "reports"
+    assert reporting.max_rows == 500
+    # The default connection is unaffected by named-connection vars.
+    assert registry.config_for().host == "localhost"
+
+
+def test_registry_named_selection_is_case_insensitive() -> None:
+    env = BASE_ENV | {
+        "CUBRID_CONNECTIONS": "Reporting",
+        "CUBRID_REPORTING_HOST": "reporting-db",
+        "CUBRID_REPORTING_USER": "ru",
+        "CUBRID_REPORTING_PASSWORD": "rp",
+        "CUBRID_REPORTING_DATABASE": "reports",
+    }
+    registry = ConnectionRegistry.from_env(env)
+    assert registry.config_for("reporting").host == "reporting-db"
+    assert registry.config_for("REPORTING").host == "reporting-db"
+
+
+def test_registry_missing_named_vars_fail_with_name() -> None:
+    env = BASE_ENV | {"CUBRID_CONNECTIONS": "reporting"}
+    with pytest.raises(ConfigError, match="CUBRID_REPORTING_HOST"):
+        ConnectionRegistry.from_env(env)
+
+
+def test_registry_reserved_default_name() -> None:
+    with pytest.raises(ConfigError, match="reserved"):
+        ConnectionRegistry.from_env(BASE_ENV | {"CUBRID_CONNECTIONS": "default"})
+
+
+def test_registry_invalid_name() -> None:
+    with pytest.raises(ConfigError, match="invalid connection name"):
+        ConnectionRegistry.from_env(BASE_ENV | {"CUBRID_CONNECTIONS": "bad-name"})
+
+
+def test_registry_duplicate_name_after_normalization() -> None:
+    env = BASE_ENV | {
+        "CUBRID_CONNECTIONS": "reporting,REPORTING",
+        "CUBRID_REPORTING_HOST": "reporting-db",
+        "CUBRID_REPORTING_USER": "ru",
+        "CUBRID_REPORTING_PASSWORD": "rp",
+        "CUBRID_REPORTING_DATABASE": "reports",
+    }
+    with pytest.raises(ConfigError, match="duplicate connection name"):
+        ConnectionRegistry.from_env(env)
+
+
+def test_registry_unknown_selector_lists_available() -> None:
+    registry = ConnectionRegistry.from_env(BASE_ENV)
+    with pytest.raises(ConfigError) as excinfo:
+        registry.config_for("nope")
+    message = str(excinfo.value)
+    assert "unknown connection" in message
+    assert "default" in message
+
+
+def test_registry_blank_names_in_list_are_skipped() -> None:
+    env = BASE_ENV | {
+        "CUBRID_CONNECTIONS": "reporting, ,",
+        "CUBRID_REPORTING_HOST": "reporting-db",
+        "CUBRID_REPORTING_USER": "ru",
+        "CUBRID_REPORTING_PASSWORD": "rp",
+        "CUBRID_REPORTING_DATABASE": "reports",
+    }
+    registry = ConnectionRegistry.from_env(env)
+    assert registry.names == ["default", "reporting"]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from cubrid_mcp_server import context as context_module
-from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.config import Config, ConfigError, ConnectionRegistry
 from cubrid_mcp_server.context import AppContext
 
 _TEST_CONFIG = Config(
@@ -21,36 +21,103 @@ _TEST_CONFIG = Config(
     max_rows=1000,
 )
 
+_REPORTING_CONFIG = Config(
+    host="reporting-db",
+    port=33000,
+    user="ru",
+    password="",
+    database="reports",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
 
-def test_from_env_builds_config_and_database(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def test_from_env_builds_a_database_per_connection(monkeypatch: pytest.MonkeyPatch) -> None:
     built: list[Config] = []
 
     class _FakeDatabase:
         def __init__(self, config: Config) -> None:
             built.append(config)
 
-    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG, "reporting": _REPORTING_CONFIG})
+    monkeypatch.setattr(ConnectionRegistry, "from_env", classmethod(lambda cls, env=None: registry))
     monkeypatch.setattr(context_module, "Database", _FakeDatabase)
 
     ctx = AppContext.from_env()
-    assert ctx.config is _TEST_CONFIG
-    assert built == [_TEST_CONFIG]
+    assert ctx.config_for() is _TEST_CONFIG
+    assert ctx.config_for("reporting") is _REPORTING_CONFIG
+    assert built == [_TEST_CONFIG, _REPORTING_CONFIG]
 
 
-def test_close_delegates_to_database() -> None:
-    closed: list[bool] = []
+def test_single_builds_a_default_only_context() -> None:
+    sentinel: Any = object()
+    ctx = AppContext.single(config=_TEST_CONFIG, database=sentinel)
+    assert ctx.config_for() is _TEST_CONFIG
+    assert ctx.database_for() is sentinel
+    assert ctx.registry.names == ["default"]
+
+
+def test_database_for_selects_named_connection() -> None:
+    default_db: Any = object()
+    reporting_db: Any = object()
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG, "reporting": _REPORTING_CONFIG})
+    ctx = AppContext(
+        registry=registry,
+        databases={"default": default_db, "reporting": reporting_db},
+    )
+    assert ctx.database_for() is default_db
+    assert ctx.database_for("reporting") is reporting_db
+    # Selection is case-insensitive and whitespace-tolerant.
+    assert ctx.database_for("  REPORTING ") is reporting_db
+    assert ctx.config_for("reporting") is _REPORTING_CONFIG
+
+
+def test_database_for_unknown_connection_raises() -> None:
+    ctx = AppContext.single(config=_TEST_CONFIG, database=object())  # type: ignore[arg-type]
+    with pytest.raises(ConfigError) as excinfo:
+        ctx.database_for("nope")
+    assert "unknown connection" in str(excinfo.value)
+    assert "default" in str(excinfo.value)
+
+
+def test_close_closes_every_database() -> None:
+    closed: list[str] = []
 
     class _FakeDatabase:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
         def close(self) -> None:
-            closed.append(True)
+            closed.append(self.label)
 
-    ctx = AppContext(config=_TEST_CONFIG, database=_FakeDatabase())  # type: ignore[arg-type]
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG, "reporting": _REPORTING_CONFIG})
+    ctx = AppContext(
+        registry=registry,
+        databases={"default": _FakeDatabase("default"), "reporting": _FakeDatabase("reporting")},  # type: ignore[dict-item]
+    )
     ctx.close()
-    assert closed == [True]
+    assert sorted(closed) == ["default", "reporting"]
 
 
-def test_appcontext_holds_injected_instances() -> None:
-    sentinel: Any = object()
-    ctx = AppContext(config=_TEST_CONFIG, database=sentinel)
-    assert ctx.database is sentinel
-    assert ctx.config is _TEST_CONFIG
+def test_close_closes_all_even_when_one_fails() -> None:
+    closed: list[str] = []
+
+    class _FailingDatabase:
+        def close(self) -> None:
+            closed.append("failing")
+            raise RuntimeError("boom")
+
+    class _OkDatabase:
+        def close(self) -> None:
+            closed.append("ok")
+
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG, "reporting": _REPORTING_CONFIG})
+    ctx = AppContext(
+        registry=registry,
+        databases={"default": _FailingDatabase(), "reporting": _OkDatabase()},  # type: ignore[dict-item]
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        ctx.close()
+    # The second database is still closed despite the first raising.
+    assert sorted(closed) == ["failing", "ok"]

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -13,7 +13,7 @@ import pytest
 
 import cubrid_mcp_server.server as server
 from cubrid_mcp_server import context as context_module
-from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.config import Config, ConfigError, ConnectionRegistry
 from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database
 from cubrid_mcp_server.safety import ensure_read_only
@@ -37,7 +37,8 @@ _TEST_CONFIG = Config(
 
 def test_context_lazily_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "_context", None)
-    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG})
+    monkeypatch.setattr(ConnectionRegistry, "from_env", classmethod(lambda cls, env=None: registry))
 
     created: list[Any] = []
 
@@ -70,13 +71,13 @@ class _NameOnlyDB:
 
 
 def test_resolve_table_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    monkeypatch.setattr(server, "_db", lambda connection=None: _NameOnlyDB(["users"]))
     with pytest.raises(ValueError, match="must not be empty"):
         server._resolve_table("   ")
 
 
 def test_resolve_table_rejects_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    monkeypatch.setattr(server, "_db", lambda connection=None: _NameOnlyDB(["users"]))
     with pytest.raises(ValueError, match="unknown table"):
         server._resolve_table("ghost")
 
@@ -120,7 +121,7 @@ class _CleanupFailingDB:
 def test_explain_query_swallows_cleanup_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """SET TRACE OFF and rollback failures during cleanup are logged, not raised."""
     monkeypatch.setattr(
-        server, "_context", AppContext(config=_TEST_CONFIG, database=_CleanupFailingDB())
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=_CleanupFailingDB())
     )
     result = server.explain_query("SELECT 1")
     assert result["plan"] == "plan text"
@@ -140,14 +141,14 @@ class _RowCountErrorDB:
 
 
 def test_table_row_counts_rejects_too_many_tables(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _NameOnlyDB(["users"]))
+    monkeypatch.setattr(server, "_db", lambda connection=None: _NameOnlyDB(["users"]))
     too_many = [f"t{i}" for i in range(server._MAX_ROW_COUNT_TABLES + 1)]
     with pytest.raises(ValueError, match="too many tables"):
         server.table_row_counts(too_many)
 
 
 def test_table_row_counts_reports_per_table_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_db", lambda: _RowCountErrorDB())
+    monkeypatch.setattr(server, "_db", lambda connection=None: _RowCountErrorDB())
     result = server.table_row_counts(["users"])
     # The raw driver message is sanitized to the exception category only.
     assert result == [{"table": "users", "row_count": None, "error": "RuntimeError"}]
@@ -169,17 +170,18 @@ def test_coerce_oversized_binary_returns_size_summary() -> None:
 
 
 def test_main_exits_on_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _raise(cls: type[Config]) -> Config:
+    def _raise(cls: type[ConnectionRegistry], env: Any = None) -> ConnectionRegistry:
         raise ConfigError("missing CUBRID_HOST")
 
-    monkeypatch.setattr(Config, "from_env", classmethod(_raise))
+    monkeypatch.setattr(ConnectionRegistry, "from_env", classmethod(_raise))
     with pytest.raises(SystemExit) as excinfo:
         server.main()
     assert excinfo.value.code == 1
 
 
 def test_main_runs_server_on_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(Config, "from_env", classmethod(lambda cls: _TEST_CONFIG))
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG})
+    monkeypatch.setattr(ConnectionRegistry, "from_env", classmethod(lambda cls, env=None: registry))
     monkeypatch.setattr(server, "_context", None)
     ran: list[bool] = []
     monkeypatch.setattr(server.mcp, "run", lambda: ran.append(True))

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -237,7 +237,9 @@ class _FakeConnDB:
     ],
 )
 def test_explain_query_accepts_select_and_with(sql: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=_FakeConnDB()))
+    monkeypatch.setattr(
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=_FakeConnDB())
+    )
     result = server.explain_query(sql)
     assert "plan" in result and "sql" in result
 
@@ -252,7 +254,9 @@ def test_explain_query_accepts_select_and_with(sql: str, monkeypatch: pytest.Mon
     ],
 )
 def test_explain_query_rejects_writes(sql: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=_FakeConnDB()))
+    monkeypatch.setattr(
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=_FakeConnDB())
+    )
     with pytest.raises(ValueError):
         server.explain_query(sql)
 
@@ -271,7 +275,9 @@ def test_explain_query_always_read_only_even_when_readonly_disabled(
         max_chars=4000,
         max_rows=1000,
     )
-    monkeypatch.setattr(server, "_context", AppContext(config=write_mode, database=_FakeConnDB()))
+    monkeypatch.setattr(
+        server, "_context", AppContext.single(config=write_mode, database=_FakeConnDB())
+    )
     with pytest.raises(ValueError):
         server.explain_query("DELETE FROM users")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,7 +35,7 @@ class TestCubridIntegration:
         self.config = Config.from_env()
         self.db = Database(self.config)
         # Route the server tool functions at the live database.
-        server._context = AppContext(config=self.config, database=self.db)
+        server._context = AppContext.single(config=self.config, database=self.db)
 
     def teardown_method(self) -> None:
         from cubrid_mcp_server import server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,7 +57,7 @@ class FakeDatabase:
 @pytest.fixture
 def fake_db(monkeypatch: pytest.MonkeyPatch) -> FakeDatabase:
     fake = FakeDatabase()
-    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=fake))
+    monkeypatch.setattr(server, "_context", AppContext.single(config=_TEST_CONFIG, database=fake))
     return fake
 
 
@@ -200,7 +200,7 @@ class FakeConnDatabase(FakeDatabase):
 
 def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = FakeConnDatabase()
-    monkeypatch.setattr(server, "_context", AppContext(config=_TEST_CONFIG, database=fake))
+    monkeypatch.setattr(server, "_context", AppContext.single(config=_TEST_CONFIG, database=fake))
     result = server.explain_query("SELECT 1")
     assert result["sql"] == "SELECT 1"
     assert "Trace Statistics" in result["plan"]
@@ -213,7 +213,7 @@ def test_explain_query_uses_trace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=FakeConnDatabase())
     )
     with pytest.raises(ValueError):
         server.explain_query("DROP TABLE users")
@@ -221,7 +221,7 @@ def test_explain_query_rejects_non_select(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_explain_query_rejects_multistatement(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=FakeConnDatabase())
     )
     with pytest.raises((ValueError, UnsafeSQLError)):
         server.explain_query("SELECT 1; DROP TABLE users")
@@ -229,7 +229,7 @@ def test_explain_query_rejects_multistatement(monkeypatch: pytest.MonkeyPatch) -
 
 def test_explain_query_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        server, "_context", AppContext(config=_TEST_CONFIG, database=FakeConnDatabase())
+        server, "_context", AppContext.single(config=_TEST_CONFIG, database=FakeConnDatabase())
     )
     with pytest.raises(ValueError):
         server.explain_query("   ")
@@ -240,7 +240,7 @@ _SHORT_SQL_CONFIG = replace(_TEST_CONFIG, max_sql_length=32)
 
 def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        server, "_context", AppContext(config=_SHORT_SQL_CONFIG, database=FakeConnDatabase())
+        server, "_context", AppContext.single(config=_SHORT_SQL_CONFIG, database=FakeConnDatabase())
     )
     with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
         server.explain_query("SELECT " + "a" * 100)
@@ -249,7 +249,9 @@ def test_explain_query_rejects_oversized_sql(monkeypatch: pytest.MonkeyPatch) ->
 def test_execute_query_rejects_oversized_sql(
     fake_db: FakeDatabase, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(server, "_context", AppContext(config=_SHORT_SQL_CONFIG, database=fake_db))
+    monkeypatch.setattr(
+        server, "_context", AppContext.single(config=_SHORT_SQL_CONFIG, database=fake_db)
+    )
     with pytest.raises(ValueError, match="CUBRID_MCP_MAX_SQL_LENGTH"):
         server.execute_query("SELECT " + "a" * 100)
     # The oversized statement is rejected before it ever reaches the database.
@@ -333,7 +335,7 @@ def test_execute_query_renders_and_truncates(
         max_chars=10,
         max_rows=1000,
     )
-    monkeypatch.setattr(server, "_context", AppContext(config=cfg, database=fake_db))
+    monkeypatch.setattr(server, "_context", AppContext.single(config=cfg, database=fake_db))
     fake_db.queue([("short",), ("a-much-longer-row",)])
     result = server.execute_query("SELECT 1")
     assert result["row_count"] == 1
@@ -346,3 +348,37 @@ def test_render_rows_returns_first_row_when_oversized() -> None:
     assert out["truncated"] is True
     # The single oversized value is itself truncated to the char budget.
     assert out["rows"] == [["a-ve\u2026"]]
+
+
+def test_connection_selector_routes_to_named_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cubrid_mcp_server.config import ConnectionRegistry
+
+    default_db = FakeDatabase()
+    reporting_db = FakeDatabase()
+    reporting_cfg = replace(_TEST_CONFIG, host="reporting-db", database="reports")
+    registry = ConnectionRegistry(configs={"default": _TEST_CONFIG, "reporting": reporting_cfg})
+    ctx = AppContext(
+        registry=registry,
+        databases={"default": default_db, "reporting": reporting_db},  # type: ignore[dict-item]
+    )
+    monkeypatch.setattr(server, "_context", ctx)
+
+    default_db.queue([("users",)])
+    reporting_db.queue([("events",)])
+
+    assert server.all_table_names() == ["users"]
+    assert server.all_table_names(connection="reporting") == ["events"]
+    # The default database saw only the default call; reporting saw only its own.
+    assert len(default_db.calls) == 1
+    assert len(reporting_db.calls) == 1
+
+
+def test_connection_selector_unknown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cubrid_mcp_server.config import ConfigError
+
+    fake = FakeDatabase()
+    monkeypatch.setattr(server, "_context", AppContext.single(config=_TEST_CONFIG, database=fake))
+    with pytest.raises(ConfigError, match="unknown connection"):
+        server.all_table_names(connection="nope")


### PR DESCRIPTION
## Summary
Serves multiple CUBRID databases from one server process, selectable per tool call. Closes #126.

- **Backward compatible:** the bare `CUBRID_*` variables continue to define the reserved `default` connection. With no `CUBRID_CONNECTIONS` set, behavior is exactly as before.
- **Named connections:** list them in `CUBRID_CONNECTIONS=reporting,analytics` and configure each via `CUBRID_<NAME>_*` (connection fields) and `CUBRID_<NAME>_MCP_*` (per-connection tuning). Names are validated `[A-Za-z0-9_]+`, matched case-insensitively; `default` is reserved; duplicates after normalization are rejected.
- **Per-call selector:** every one of the 11 tools takes an optional final `connection` argument, resolved via `_db()`/`_cfg()`. Each connection keeps its own `Database` (its own lock, read-only enforcement, and stale-connection lifecycle). No shared/global "current connection" state.
- Unknown connection names raise a clear, client-safe error listing the available connections.

## Design
Implemented per Oracle **design review** (APPROVE WITH CHANGES) and confirmed by Oracle **post-implementation review** (APPROVE, no blockers). Follows the cubrid-lab workflow: design review → implementation + tests → docs → post-impl review.

- `config.py`: `Config.from_env` refactored onto a shared prefix-based `_parse_config`; new frozen `ConnectionRegistry` with `config_for(connection)`.
- `context.py`: `AppContext` now owns a `{name -> Database}` registry with `database_for()`/`config_for()`; `close()` closes every database best-effort and re-raises the first error. `AppContext.single()` preserves single-connection construction.
- `server.py`: `connection` threaded through all tools and internal helpers.

## Tests
183 passing, coverage 98.43% (config.py & context.py 100%, server.py 99%). New tests cover registry parsing edge cases (reserved `default`, invalid/duplicate names, missing named vars with the name in the error, empty/whitespace selector → default, blank names skipped, case-insensitive selection, unknown selector lists available), close-all (including when one close fails), and server-level connection routing + unknown-connection error.

## Docs
- `README.md`: new "Multiple connections" configuration subsection.
- `CHANGELOG.md`: `[Unreleased]/Added` entry (#126).