### PR TITLE
feat: add opt-in query audit logging (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Opt-in audit logging (`CUBRID_MCP_AUDIT_LOG`, off by default): emits one redaction-safe JSON record per executed statement (`execute_query`/`explain_query`) to stderr with the statement category, extracted table identifiers, timing, and row counts. Raw SQL text, bound parameters, and literal values are never logged. (#127)
 - `ROADMAP.md` describing the current baseline, future direction, compatibility, and shipped history, matching the sibling repos in the Python line. (#96)
 - Repo-local `CONTRIBUTING.md` documenting the Makefile targets, the CI gates a PR must clear (ruff, mypy strict, 95% coverage floor, lowest-direct, changelog lint), and how to run the integration suite against a live CUBRID. (#94)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Optional settings:
 | `CUBRID_MCP_MAX_ROWS` | `1000` | Max rows returned by `execute_query` before truncation |
 | `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
 | `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
+| `CUBRID_MCP_AUDIT_LOG` | `0` | Opt-in audit logging. When enabled, emits one redaction-safe JSON record per executed statement (`execute_query`/`explain_query`) to **stderr** — see [Logging](#logging). |
 
 ### Run
 
@@ -148,6 +149,23 @@ For production use, also configure a read-only database user. See [`SECURITY.md`
 The server speaks the MCP **stdio transport**, where `stdout` carries the JSON-RPC protocol stream. Anything written to `stdout` by the server or its dependencies will corrupt that stream and break the client connection. For this reason **all logging is routed to `stderr`**, and you should keep it that way: when adding custom logging or diagnostics, never `print()` to `stdout` — use the standard `logging` module (which is configured to emit on `stderr`) or write to `stderr` explicitly. The log level defaults to `INFO`.
 
 Errors surfaced back to the LLM client are **sanitized**: only the exception category (e.g. `query failed: OperationalError`) is returned, while the full exception detail is logged to `stderr` for operators. This keeps schema details, hostnames, SQL fragments, and configuration values out of client-visible messages.
+
+### Audit logging (opt-in)
+
+Set `CUBRID_MCP_AUDIT_LOG=1` to record every executed statement (`execute_query` and `explain_query`) as a single structured JSON line on **stderr**. It is **off by default**. Each record is redaction-safe and contains only:
+
+| Field | Description |
+|-------|-------------|
+| `tool` | The MCP tool that ran the statement (`execute_query` / `explain_query`). |
+| `status` | `ok` or `error`. |
+| `category` | The leading SQL keyword only (e.g. `SELECT`, `WITH`) — never the full statement. |
+| `identifiers` | Table names extracted after `FROM`/`JOIN` via a strict identifier regex; anything that is not a bare identifier (values, literals, expressions) is dropped. |
+| `sql_length` | Length of the submitted SQL, in characters. |
+| `row_count`, `truncated` | Result size and whether output was truncated (success only). |
+| `duration_ms` | Wall-clock duration of the call, in integer milliseconds. |
+| `error_type` | On failure, the exception **class name only** (via the same sanitization as client-facing errors). |
+
+The **raw SQL text, bound parameters, and literal values are never logged**, so secrets embedded in a query (e.g. `WHERE token = '...'`) do not reach the audit stream. Records go to `stderr` only and never to `stdout`.
 
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,19 @@ You can disable this layer by setting `CUBRID_MCP_READONLY=0`, but only do so wh
 
 `execute_query` caps the number of rows returned at `CUBRID_MCP_MAX_ROWS` (default 1000) and truncates rendered output once the cumulative character count exceeds `CUBRID_MCP_MAX_CHARS` (default 4000). Together these protect the model's context window and limit how much data a single probing query can exfiltrate in one shot. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large, so raw blobs never flood the output.
 
+## Layer 4 — audit logging (opt-in)
+
+Set `CUBRID_MCP_AUDIT_LOG=1` to emit a structured JSON record on **stderr** for every executed statement (`execute_query`, `explain_query`), for observability and after-the-fact security review. It is **off by default**.
+
+Audit records are deliberately redaction-safe and share the same sanitization guarantees as client-facing errors:
+
+- Only the statement **category** (leading keyword) and **table identifiers** (extracted via a strict identifier regex) are recorded — never the raw SQL text.
+- **Bound parameters and literal values are never logged**, so a secret embedded in a query (`WHERE token = '…'`) does not appear in the audit stream.
+- Failures record the exception **class name only** (via `sanitize_error`), never the raw driver message.
+- Records go to `stderr` only; `stdout` remains reserved for the MCP protocol stream.
+
+This complements — but does not replace — CUBRID's own server-side query logging.
+
 
 
 ## LLM threat model

--- a/cubrid_mcp_server/audit.py
+++ b/cubrid_mcp_server/audit.py
@@ -1,0 +1,200 @@
+"""Opt-in, redaction-safe audit logging for executed statements.
+
+When ``CUBRID_MCP_AUDIT_LOG`` is enabled (off by default) the server emits one
+structured JSON record per audited statement so operators can review what the
+LLM ran — statement *category*, timing, row counts, and conservatively
+extracted table identifiers. It is a security/observability aid, not a full
+query log.
+
+Redaction is a hard invariant:
+
+- The **raw SQL text is never logged** — only its leading keyword (category),
+  its length, and table identifiers that match a strict identifier regex.
+- Bound parameters and literal values are never logged.
+- Errors are reduced to the exception class name via
+  :func:`cubrid_mcp_server.database.sanitize_error`, never the raw message.
+
+Records are written to **stderr only**. stdout is reserved for the MCP
+JSON-RPC protocol stream, so the audit logger uses a dedicated logger with a
+late-bound stderr handler and ``propagate = False`` — it can never leak onto
+stdout even if an embedder points root logging there.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterator, TextIO
+
+from cubrid_mcp_server.database import sanitize_error
+
+_AUDIT_LOGGER_NAME = "cubrid_mcp_server.audit"
+
+# A single, strict SQL identifier: a bare or double-quoted name, optionally
+# schema-qualified (``schema.table``). Deliberately conservative — anything that
+# does not match this shape is dropped rather than risk echoing a literal.
+_IDENTIFIER = r'(?:"[A-Za-z_][A-Za-z0-9_]*"|[A-Za-z_][A-Za-z0-9_]*)'
+_TABLE_REF = re.compile(
+    rf"\b(?:FROM|JOIN)\s+({_IDENTIFIER}(?:\.{_IDENTIFIER})?)",
+    re.IGNORECASE,
+)
+_LEADING_WORD = re.compile(r"[A-Za-z]+")
+
+# SQL noise that must never be inspected for identifiers: single-quoted string
+# literals (with doubled-quote escapes), line comments, and block comments.
+# These are blanked out before the ``FROM``/``JOIN`` scan so a literal or comment
+# such as ``'JOIN secret'`` or ``-- JOIN secret`` can never echo an identifier.
+_SQL_NOISE = re.compile(
+    r"'(?:[^']|'')*'"  # single-quoted string literal
+    r"|--[^\n]*"  # line comment
+    r"|/\*.*?\*/",  # block comment
+    re.DOTALL,
+)
+
+
+def _strip_noise(sql: str) -> str:
+    """Blank out string literals and comments so identifier extraction never
+    inspects quoted or commented text."""
+    return _SQL_NOISE.sub(" ", sql)
+
+
+def _category(sql: str | None) -> str | None:
+    """Return the leading SQL keyword (uppercased) or ``None``.
+
+    Only the first alphabetic run is inspected, so no literal or identifier can
+    be echoed through this field.
+    """
+    if not sql:
+        return None
+    match = _LEADING_WORD.match(sql.lstrip())
+    return match.group(0).upper() if match else None
+
+
+def _identifiers(sql: str | None) -> list[str]:
+    """Extract table identifiers following ``FROM``/``JOIN`` via a strict regex.
+
+    Anything not matching :data:`_IDENTIFIER` is ignored, so values, quoted
+    string literals, and expressions are never surfaced. Order-preserving and
+    de-duplicated.
+    """
+    if not sql:
+        return []
+    seen: dict[str, None] = {}
+    for raw in _TABLE_REF.findall(_strip_noise(sql)):
+        name = raw.replace('"', "")
+        if name not in seen:
+            seen[name] = None
+    return list(seen)
+
+
+if TYPE_CHECKING:
+    _BaseStreamHandler = logging.StreamHandler[TextIO]
+else:
+    _BaseStreamHandler = logging.StreamHandler
+
+
+class _AuditHandler(_BaseStreamHandler):
+    """Marker ``StreamHandler`` subclass so we can find and replace our own
+    audit handler on the shared named logger (deduplication across repeated
+    ``AuditLogger`` construction in tests / re-init) without touching handlers
+    installed by anyone else.
+    """
+
+
+@dataclass
+class _Outcome:
+    """Mutable sink for values a caller learns *during* an audited call."""
+
+    row_count: int | None = None
+    truncated: bool | None = None
+
+
+class AuditLogger:
+    """Emit opt-in, redaction-safe audit records to stderr.
+
+    When ``enabled`` is ``False`` every method is a cheap no-op, so the tools
+    can call it unconditionally.
+    """
+
+    def __init__(self, enabled: bool, *, stream: TextIO | None = None) -> None:
+        self.enabled = enabled
+        self._logger = logging.getLogger(_AUDIT_LOGGER_NAME)
+        if not enabled:
+            return
+        self._logger.setLevel(logging.INFO)
+        # Never propagate to the root logger, which an embedder may have
+        # pointed at stdout — audit output must stay on stderr.
+        self._logger.propagate = False
+        # This is a dedicated, non-propagating logger, so any pre-existing
+        # handler (e.g. one an embedder pointed at stdout) must be removed —
+        # not just our own marker handler — before installing the stderr one.
+        # This also dedups repeated construction (tests, re-init).
+        for handler in list(self._logger.handlers):
+            self._logger.removeHandler(handler)
+        emit = _AuditHandler(stream if stream is not None else sys.stderr)
+        emit.setFormatter(logging.Formatter("%(message)s"))
+        self._logger.addHandler(emit)
+
+    def record(
+        self,
+        *,
+        tool: str,
+        status: str,
+        sql: str | None = None,
+        row_count: int | None = None,
+        truncated: bool | None = None,
+        duration_ms: int | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        """Emit a single JSON audit record (no-op when disabled)."""
+        if not self.enabled:
+            return
+        payload: dict[str, Any] = {
+            "event": "statement",
+            "tool": tool,
+            "status": status,
+            "category": _category(sql),
+            "identifiers": _identifiers(sql),
+            "sql_length": len(sql) if sql is not None else None,
+            "row_count": row_count,
+            "truncated": truncated,
+            "duration_ms": duration_ms,
+            "error_type": error_type,
+        }
+        self._logger.info(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+    @contextmanager
+    def track(self, tool: str, sql: str | None = None) -> Iterator[_Outcome]:
+        """Time an audited call, emitting a record on success and on failure.
+
+        Yields a mutable :class:`_Outcome` the caller may populate with
+        ``row_count``/``truncated``. Exceptions are audited (with a sanitized
+        error type) and then re-raised unchanged.
+        """
+        outcome = _Outcome()
+        start = time.perf_counter()
+        try:
+            yield outcome
+        except BaseException as exc:
+            self.record(
+                tool=tool,
+                status="error",
+                sql=sql,
+                duration_ms=int((time.perf_counter() - start) * 1000),
+                error_type=sanitize_error(exc),
+            )
+            raise
+        else:
+            self.record(
+                tool=tool,
+                status="ok",
+                sql=sql,
+                row_count=outcome.row_count,
+                truncated=outcome.truncated,
+                duration_ms=int((time.perf_counter() - start) * 1000),
+            )

--- a/cubrid_mcp_server/config.py
+++ b/cubrid_mcp_server/config.py
@@ -22,6 +22,7 @@ class Config:
     max_rows: int
     max_sql_length: int = 65536
     query_timeout: float = 30.0
+    audit_log: bool = False
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Config":
@@ -82,6 +83,8 @@ class Config:
         if query_timeout <= 0:
             raise ConfigError("CUBRID_MCP_QUERY_TIMEOUT must be positive")
 
+        audit_log = _parse_bool(source.get("CUBRID_MCP_AUDIT_LOG", "0"))
+
         return cls(
             host=host,
             port=port,
@@ -93,6 +96,7 @@ class Config:
             max_rows=max_rows,
             max_sql_length=max_sql_length,
             query_timeout=query_timeout,
+            audit_log=audit_log,
         )
 
 

--- a/cubrid_mcp_server/context.py
+++ b/cubrid_mcp_server/context.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from cubrid_mcp_server.audit import AuditLogger
 from cubrid_mcp_server.config import Config
 from cubrid_mcp_server.database import Database
 
@@ -21,12 +22,23 @@ class AppContext:
 
     config: Config
     database: Database
+    audit: AuditLogger | None = None
+
+    def __post_init__(self) -> None:
+        # Derive a disabled/enabled audit logger from config when one is not
+        # explicitly injected, so every context always has a usable ``audit``.
+        if self.audit is None:
+            object.__setattr__(self, "audit", AuditLogger(self.config.audit_log))
 
     @classmethod
     def from_env(cls) -> "AppContext":
         """Build a context from environment configuration."""
         config = Config.from_env()
-        return cls(config=config, database=Database(config))
+        return cls(
+            config=config,
+            database=Database(config),
+            audit=AuditLogger(config.audit_log),
+        )
 
     def close(self) -> None:
         """Release the underlying database connection."""

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
+from cubrid_mcp_server.audit import AuditLogger
 from cubrid_mcp_server.config import Config, ConfigError
 from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database, sanitize_error
@@ -51,6 +52,12 @@ def _db() -> Database:
 
 def _cfg() -> Config:
     return _get_context().config
+
+
+def _audit() -> AuditLogger:
+    audit = _get_context().audit
+    assert audit is not None  # AppContext.__post_init__ always populates this
+    return audit
 
 
 def _all_table_names() -> list[str]:
@@ -190,34 +197,35 @@ def list_indexes(table_name: str) -> list[dict[str, Any]]:
 @mcp.tool
 def explain_query(sql: str) -> dict[str, Any]:
     """Return CUBRID's execution plan/trace for a ``SELECT`` or ``WITH`` statement."""
-    cleaned = sql.strip().rstrip(";").strip()
-    if not cleaned:
-        raise ValueError("empty SQL statement")
-    config = _cfg()
-    if len(cleaned) > config.max_sql_length:
-        raise ValueError(
-            f"SQL exceeds maximum length of {config.max_sql_length} characters "
-            f"(CUBRID_MCP_MAX_SQL_LENGTH)"
-        )
-    leading = cleaned.split(None, 1)[0].upper()
-    if leading not in {"SELECT", "WITH"}:
-        raise ValueError("explain_query only accepts SELECT or WITH statements")
-    # explain_query is *intentionally* always read-only, regardless of
-    # ``config.readonly``: it can only ever produce a plan for a SELECT/WITH query,
-    # so there is no meaningful write-mode behavior to gate. This differs from
-    # execute_query, which honors CUBRID_MCP_READONLY. ensure_read_only also rejects
-    # embedded second statements (e.g. "SELECT 1; DROP TABLE x") as defense in depth.
-    ensure_read_only(cleaned)
+    with _audit().track("explain_query", sql):
+        cleaned = sql.strip().rstrip(";").strip()
+        if not cleaned:
+            raise ValueError("empty SQL statement")
+        config = _cfg()
+        if len(cleaned) > config.max_sql_length:
+            raise ValueError(
+                f"SQL exceeds maximum length of {config.max_sql_length} characters "
+                f"(CUBRID_MCP_MAX_SQL_LENGTH)"
+            )
+        leading = cleaned.split(None, 1)[0].upper()
+        if leading not in {"SELECT", "WITH"}:
+            raise ValueError("explain_query only accepts SELECT or WITH statements")
+        # explain_query is *intentionally* always read-only, regardless of
+        # ``config.readonly``: it can only ever produce a plan for a SELECT/WITH query,
+        # so there is no meaningful write-mode behavior to gate. This differs from
+        # execute_query, which honors CUBRID_MCP_READONLY. ensure_read_only also rejects
+        # embedded second statements (e.g. "SELECT 1; DROP TABLE x") as defense in depth.
+        ensure_read_only(cleaned)
 
-    plan = ""
-    with _db().trace_enabled() as cursor:
-        cursor.execute(cleaned, ())
-        cursor.execute("SHOW TRACE", ())
-        trace_rows = cursor.fetchall()
-        if trace_rows and trace_rows[0]:
-            plan = str(trace_rows[0][0] or "").strip()
+        plan = ""
+        with _db().trace_enabled() as cursor:
+            cursor.execute(cleaned, ())
+            cursor.execute("SHOW TRACE", ())
+            trace_rows = cursor.fetchall()
+            if trace_rows and trace_rows[0]:
+                plan = str(trace_rows[0][0] or "").strip()
 
-    return {"sql": cleaned, "plan": plan}
+        return {"sql": cleaned, "plan": plan}
 
 
 @mcp.tool
@@ -304,21 +312,24 @@ def execute_query(sql: str) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
     db = _db()
     config = _cfg()
-    if len(sql) > config.max_sql_length:
-        raise ValueError(
-            f"SQL exceeds maximum length of {config.max_sql_length} characters "
-            f"(CUBRID_MCP_MAX_SQL_LENGTH)"
-        )
-    if config.readonly:
-        ensure_read_only(sql)
+    with _audit().track("execute_query", sql) as outcome:
+        if len(sql) > config.max_sql_length:
+            raise ValueError(
+                f"SQL exceeds maximum length of {config.max_sql_length} characters "
+                f"(CUBRID_MCP_MAX_SQL_LENGTH)"
+            )
+        if config.readonly:
+            ensure_read_only(sql)
 
-    rows, row_truncated = db.fetch_many(sql, None, config.max_rows)
-    rendered = _render_rows(rows, config.max_chars)
-    return {
-        "row_count": len(rendered["rows"]),
-        "truncated": bool(rendered["truncated"] or row_truncated),
-        "rows": rendered["rows"],
-    }
+        rows, row_truncated = db.fetch_many(sql, None, config.max_rows)
+        rendered = _render_rows(rows, config.max_chars)
+        outcome.row_count = len(rendered["rows"])
+        outcome.truncated = bool(rendered["truncated"] or row_truncated)
+        return {
+            "row_count": outcome.row_count,
+            "truncated": outcome.truncated,
+            "rows": rendered["rows"],
+        }
 
 
 @mcp.tool

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -161,13 +161,9 @@ def test_error_path_is_audited_and_redacted() -> None:
     audit = AuditLogger(True, stream=buf)
     sql = f"DELETE FROM users WHERE pw = '{_SECRET}'"
 
-    raised = False
-    try:
+    with pytest.raises(ValueError):
         with audit.track("execute_query", sql):
             raise ValueError(f"boom {_SECRET}")
-    except ValueError:
-        raised = True
-    assert raised
 
     records = _records(buf)
     assert len(records) == 1

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -161,9 +161,13 @@ def test_error_path_is_audited_and_redacted() -> None:
     audit = AuditLogger(True, stream=buf)
     sql = f"DELETE FROM users WHERE pw = '{_SECRET}'"
 
-    with pytest.raises(ValueError, match="boom"):
+    raised = False
+    try:
         with audit.track("execute_query", sql):
             raise ValueError(f"boom {_SECRET}")
+    except ValueError:
+        raised = True
+    assert raised
 
     records = _records(buf)
     assert len(records) == 1

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,251 @@
+"""Unit tests for opt-in audit logging (issue #127).
+
+Covers the redaction invariants (no raw SQL / no literal values leak), the
+stderr-only guarantee, off-by-default behaviour, and identifier/category
+extraction.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from cubrid_mcp_server import server
+from cubrid_mcp_server.audit import AuditLogger, _category, _identifiers
+from cubrid_mcp_server.config import Config
+from cubrid_mcp_server.context import AppContext
+
+_SECRET = "p@ssw0rd-should-never-appear"
+
+_BASE_CONFIG = Config(
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
+
+
+class FakeDatabase:
+    """Minimal Database stand-in returning canned rows."""
+
+    def __init__(self, rows: list[tuple[Any, ...]] | None = None) -> None:
+        self._rows = rows or []
+
+    def fetch_many(
+        self,
+        sql: str,
+        params: tuple[Any, ...] | None = None,
+        max_rows: int | None = None,
+    ) -> tuple[list[tuple[Any, ...]], bool]:
+        return self._rows, False
+
+
+def _records(buf: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# Config parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_audit_log_off_by_default() -> None:
+    cfg = Config.from_env(
+        {
+            "CUBRID_HOST": "h",
+            "CUBRID_USER": "u",
+            "CUBRID_PASSWORD": "p",
+            "CUBRID_DATABASE": "d",
+        }
+    )
+    assert cfg.audit_log is False
+
+
+def test_audit_log_enabled_via_env() -> None:
+    cfg = Config.from_env(
+        {
+            "CUBRID_HOST": "h",
+            "CUBRID_USER": "u",
+            "CUBRID_PASSWORD": "p",
+            "CUBRID_DATABASE": "d",
+            "CUBRID_MCP_AUDIT_LOG": "1",
+        }
+    )
+    assert cfg.audit_log is True
+
+
+# --------------------------------------------------------------------------- #
+# Extraction helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_category_is_leading_keyword_only() -> None:
+    assert _category("  select * from users") == "SELECT"
+    assert _category("WITH t AS (SELECT 1) SELECT * FROM t") == "WITH"
+    assert _category("") is None
+    assert _category("123 select") is None
+    assert _category(None) is None
+
+
+def test_identifiers_strict_and_deduplicated() -> None:
+    sql = "SELECT * FROM orders o JOIN customers c ON o.cid = c.id JOIN orders x"
+    assert _identifiers(sql) == ["orders", "customers"]
+    assert _identifiers("") == []
+    assert _identifiers(None) == []
+
+
+def test_identifiers_ignore_literals_and_subqueries() -> None:
+    sql = f"SELECT * FROM users WHERE note = '{_SECRET}'"
+    ids = _identifiers(sql)
+    assert ids == ["users"]
+    assert _SECRET not in "".join(ids)
+
+
+def test_identifiers_ignore_join_inside_literals_and_comments() -> None:
+    # A FROM/JOIN appearing inside a string literal or comment must never be
+    # surfaced as an identifier (blocker: literal/comment leakage).
+    assert _identifiers(f"SELECT * FROM real WHERE x = 'JOIN {_SECRET}'") == ["real"]
+    assert _identifiers("SELECT * FROM real -- JOIN commented_out\n") == ["real"]
+    assert _identifiers("SELECT * FROM real /* JOIN blocked */ WHERE 1=1") == ["real"]
+    assert _SECRET not in "".join(_identifiers(f"SELECT 1 FROM t WHERE note = 'FROM {_SECRET}'"))
+
+
+# --------------------------------------------------------------------------- #
+# AuditLogger behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_disabled_logger_emits_nothing() -> None:
+    buf = io.StringIO()
+    audit = AuditLogger(False, stream=buf)
+    with audit.track("execute_query", f"SELECT '{_SECRET}'") as outcome:
+        outcome.row_count = 1
+    audit.record(tool="execute_query", status="ok", sql="SELECT 1")
+    assert buf.getvalue() == ""
+
+
+def test_success_record_shape_and_redaction() -> None:
+    buf = io.StringIO()
+    audit = AuditLogger(True, stream=buf)
+    sql = f"SELECT id FROM users WHERE pw = '{_SECRET}'"
+    with audit.track("execute_query", sql) as outcome:
+        outcome.row_count = 3
+        outcome.truncated = False
+
+    records = _records(buf)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["tool"] == "execute_query"
+    assert rec["status"] == "ok"
+    assert rec["category"] == "SELECT"
+    assert rec["identifiers"] == ["users"]
+    assert rec["row_count"] == 3
+    assert rec["truncated"] is False
+    assert rec["sql_length"] == len(sql)
+    assert isinstance(rec["duration_ms"], int)
+    # Redaction: neither the secret literal nor the raw SQL text appears.
+    assert _SECRET not in buf.getvalue()
+    assert sql not in buf.getvalue()
+
+
+def test_error_path_is_audited_and_redacted() -> None:
+    buf = io.StringIO()
+    audit = AuditLogger(True, stream=buf)
+    sql = f"DELETE FROM users WHERE pw = '{_SECRET}'"
+
+    with pytest.raises(ValueError, match="boom"):
+        with audit.track("execute_query", sql):
+            raise ValueError(f"boom {_SECRET}")
+
+    records = _records(buf)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["status"] == "error"
+    assert rec["category"] == "DELETE"
+    assert rec["error_type"] == "ValueError"  # sanitized: class name only
+    # The exception message embedded the secret; it must not be logged.
+    assert _SECRET not in buf.getvalue()
+
+
+def test_repeated_construction_does_not_double_log() -> None:
+    buf1 = io.StringIO()
+    AuditLogger(True, stream=buf1)
+    buf2 = io.StringIO()
+    audit = AuditLogger(True, stream=buf2)
+    audit.record(tool="execute_query", status="ok", sql="SELECT 1")
+    # The first logger's handler was replaced, so only buf2 receives the record.
+    assert buf1.getvalue() == ""
+    assert len(_records(buf2)) == 1
+
+
+def test_preexisting_handler_is_removed_for_stderr_only() -> None:
+    # A handler an embedder may have installed (e.g. pointed at stdout) on the
+    # dedicated audit logger must be removed so audit output stays stderr-only.
+    import logging
+
+    from cubrid_mcp_server.audit import _AUDIT_LOGGER_NAME
+
+    stray = io.StringIO()
+    logger = logging.getLogger(_AUDIT_LOGGER_NAME)
+    rogue = logging.StreamHandler(stray)
+    logger.addHandler(rogue)
+    try:
+        buf = io.StringIO()
+        audit = AuditLogger(True, stream=buf)
+        audit.record(tool="execute_query", status="ok", sql="SELECT 1")
+        assert stray.getvalue() == ""  # rogue handler was removed
+        assert len(_records(buf)) == 1
+    finally:
+        logger.removeHandler(rogue)
+
+
+# --------------------------------------------------------------------------- #
+# Server integration: stderr-only guarantee
+# --------------------------------------------------------------------------- #
+
+
+def test_execute_query_audits_without_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    buf = io.StringIO()
+    config = replace(_BASE_CONFIG, audit_log=True)
+    fake = FakeDatabase(rows=[(1,), (2,)])
+    monkeypatch.setattr(
+        server,
+        "_context",
+        AppContext(config=config, database=fake, audit=AuditLogger(True, stream=buf)),
+    )
+
+    sql = f"SELECT id FROM accounts WHERE token = '{_SECRET}'"
+    result = server.execute_query(sql)
+    assert result["row_count"] == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""  # stdout is the MCP protocol stream — must stay clean
+
+    records = _records(buf)
+    assert len(records) == 1
+    assert records[0]["tool"] == "execute_query"
+    assert records[0]["identifiers"] == ["accounts"]
+    assert _SECRET not in buf.getvalue()
+
+
+def test_execute_query_no_audit_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    buf = io.StringIO()
+    fake = FakeDatabase(rows=[(1,)])
+    # audit_log defaults False; injected logger is disabled and must emit nothing.
+    monkeypatch.setattr(
+        server,
+        "_context",
+        AppContext(config=_BASE_CONFIG, database=fake, audit=AuditLogger(False, stream=buf)),
+    )
+    server.execute_query("SELECT 1")
+    assert buf.getvalue() == ""


### PR DESCRIPTION
## Summary
Implements issue #127 — opt-in, redaction-safe audit logging of executed statements (part of the v0.3.x epic #23).

- New `cubrid_mcp_server/audit.py`: `AuditLogger` emits one structured JSON record per audited call to **stderr only** via a dedicated, non-propagating logger with an explicit stderr handler.
- Gated by `CUBRID_MCP_AUDIT_LOG` (default `0`/off). Only `execute_query` and `explain_query` are audited.
- Record fields: `event`, `tool`, `status`, `category` (leading keyword), `identifiers` (conservatively extracted table names), `sql_length`, `row_count`, `truncated`, `duration_ms`, `error_type`.
- **Redaction is a hard invariant**: raw SQL text, bound params, literal values, and driver messages are never logged. `error_type` uses `sanitize_error` (class name only).
- Threaded via `AppContext` (test-injectable), not global state.

## Oracle review
Design review: APPROVE-WITH-CHANGES (5 changes, all implemented). Post-implementation review: REQUEST CHANGES → both blockers fixed in this branch:
1. `_identifiers` now blanks out string literals and comments before the `FROM`/`JOIN` scan, so a keyword inside a quoted value/comment can never echo an identifier.
2. `AuditLogger.__init__` now removes **all** pre-existing handlers on the dedicated logger (not just its own marker) before installing the stderr handler — guaranteeing stderr-only output. Stray `_audit()` return removed.

## Tests
`tests/test_audit.py` (13 tests): off-by-default, category/identifier extraction incl. literal/comment/None cases, disabled no-op, success + error-path redaction, no-double-log, pre-installed-handler removal, and a server-level `execute_query` test asserting `stdout == ""` with the secret absent.

Local: ruff + format clean, mypy clean (except known env-only pycubrid stub), 180 passed / 14 skipped, coverage 98.52% (audit.py 100%).

## Docs
README config table row + "Audit logging (opt-in)" section; SECURITY.md "Layer 4 — audit logging (opt-in)"; CHANGELOG `[Unreleased]/Added`.