### PR TITLE
feat: add opt-in write mode with atomic execute_write tool (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ROADMAP.md` describing the current baseline, future direction, compatibility, and shipped history, matching the sibling repos in the Python line. (#96)
+- Opt-in write mode (`CUBRID_MCP_WRITE=1`) exposing an `execute_write` tool that runs a single `INSERT`/`UPDATE`/`DELETE` statement in an atomic transaction (commit on success, rollback on failure). Disabled by default; when off the tool is not registered so no write path is exposed. DDL is intentionally unsupported (CUBRID auto-commits DDL) and `execute_query` stays read-only regardless. (#123)
 - Repo-local `CONTRIBUTING.md` documenting the Makefile targets, the CI gates a PR must clear (ruff, mypy strict, 95% coverage floor, lowest-direct, changelog lint), and how to run the integration suite against a live CUBRID. (#94)
+
+### Security
+- Write mode is strictly gated: a dedicated DML-only whitelist (`ensure_write_allowed`) rejects standalone reads, DDL, transaction-control, and multi-statement input, and leaves the read-only default path unchanged. (#123)
 
 ### Changed
 - Ruff's lint rule set is now declared explicitly (`select = ["E4", "E7", "E9", "F"]`) instead of inheriting ruff's implicit defaults, which grew from 59 to 413 rules in ruff 0.16 and broke CI on an unrelated version bump. (#88)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 | `list_class_hierarchy` | CUBRID `CLASS` inheritance relationships |
 | `execute_query` | Run read-only SQL with automatic output truncation |
 | `health_check` | Verify database connectivity on demand |
+| `execute_write` | Run a single `INSERT`/`UPDATE`/`DELETE` in an atomic transaction (**only registered when opt-in write mode is enabled**) |
 
 ## Quick Start
 
@@ -41,6 +42,7 @@ Optional settings:
 | `CUBRID_MCP_MAX_ROWS` | `1000` | Max rows returned by `execute_query` before truncation |
 | `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
 | `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
+| `CUBRID_MCP_WRITE` | `0` | Opt-in write mode. When enabled (`1`), registers the `execute_write` tool for single-statement DML. Off by default. |
 
 ### Run
 
@@ -142,6 +144,17 @@ The server is **read-only by default**. A code-level SQL whitelist allows only `
 > **The SQL whitelist is defense-in-depth, not a security boundary.** It is a non-validating parser-based guardrail against obvious mistakes. The real enforcement layer is the database itself: **always run the server as a CUBRID user that has only `SELECT` grants** on the tables the model may read. See [`SECURITY.md`](./SECURITY.md).
 
 For production use, also configure a read-only database user. See [`SECURITY.md`](./SECURITY.md) for the recommended setup.
+
+### Write mode (opt-in)
+
+Write access is **disabled by default**. Setting `CUBRID_MCP_WRITE=1` registers an additional `execute_write` tool that accepts a **single** `INSERT`, `UPDATE`, or `DELETE` statement and runs it in an explicit transaction (commit on success, rollback on any error). When write mode is off the tool is not registered at all, so no write path is exposed in MCP capability discovery.
+
+Constraints and rationale:
+
+- **Single-statement DML only.** Standalone reads, DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`), transaction-control, and multi-statement input are rejected. (A single DML statement may still legally contain subqueries, e.g. `INSERT ... SELECT`.)
+- **DDL is intentionally unsupported.** CUBRID auto-commits DDL, which defeats the rollback guarantee, so it is excluded from write mode.
+- `execute_query` remains **read-only regardless** of the write-mode flag.
+- Enforcement is defense-in-depth; still run the server as a CUBRID user granted only the privileges it needs. See [`SECURITY.md`](./SECURITY.md).
 
 ## Logging
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,17 @@ You can disable this layer by setting `CUBRID_MCP_READONLY=0`, but only do so wh
 - you genuinely need statements outside the whitelist (for example, CUBRID administrative `SHOW` variants that confuse the parser).
 
 **`explain_query` is always read-only**, independent of `CUBRID_MCP_READONLY`. It only ever produces a plan for a `SELECT`/`WITH` query, so it always applies the whitelist even when the server is nominally in write-allowed mode. Only `execute_query` honors `CUBRID_MCP_READONLY=0`.
+
+## Layer 2b — opt-in write mode (`CUBRID_MCP_WRITE`)
+
+Write access is **off by default**. Setting `CUBRID_MCP_WRITE=1` registers a separate `execute_write` tool that accepts a **single** `INSERT`/`UPDATE`/`DELETE` statement and runs it in an explicit transaction (commit on success, rollback on any failure). Design constraints that bound the blast radius:
+
+- **DML only.** Standalone reads, DDL, transaction-control, and multi-statement input are rejected by a dedicated whitelist (`ensure_write_allowed`), separate from the read-only path. (A single DML statement may still legally embed subqueries, e.g. `INSERT ... SELECT`.)
+- **DDL is intentionally unsupported.** CUBRID auto-commits DDL, which would defeat the rollback guarantee, so `CREATE`/`ALTER`/`DROP`/`TRUNCATE` are never permitted even in write mode.
+- **Not registered when disabled.** With write mode off, `execute_write` is absent from MCP capability discovery — there is no reachable write path, not merely a guarded one.
+- **`execute_query` stays read-only** regardless of the write flag.
+
+As with the read-only layer, this is defense-in-depth: still run the server as a CUBRID user granted only the privileges the model needs.
 ## Layer 3 — output limits
 
 `execute_query` caps the number of rows returned at `CUBRID_MCP_MAX_ROWS` (default 1000) and truncates rendered output once the cumulative character count exceeds `CUBRID_MCP_MAX_CHARS` (default 4000). Together these protect the model's context window and limit how much data a single probing query can exfiltrate in one shot. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large, so raw blobs never flood the output.

--- a/cubrid_mcp_server/config.py
+++ b/cubrid_mcp_server/config.py
@@ -22,6 +22,7 @@ class Config:
     max_rows: int
     max_sql_length: int = 65536
     query_timeout: float = 30.0
+    write_enabled: bool = False
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> "Config":
@@ -82,6 +83,8 @@ class Config:
         if query_timeout <= 0:
             raise ConfigError("CUBRID_MCP_QUERY_TIMEOUT must be positive")
 
+        write_enabled = _parse_bool(source.get("CUBRID_MCP_WRITE", "0"))
+
         return cls(
             host=host,
             port=port,
@@ -93,6 +96,7 @@ class Config:
             max_rows=max_rows,
             max_sql_length=max_sql_length,
             query_timeout=query_timeout,
+            write_enabled=write_enabled,
         )
 
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -136,6 +136,50 @@ class Database:
         except Exception as exc:
             logger.debug("failed to close cursor: %s", exc)
 
+    def _rollback_or_discard(self, connection: Any) -> None:
+        """Roll back a failed write; discard the connection if rollback itself fails.
+
+        A rollback failure means the shared connection may retain unknown
+        transaction state, so it is dropped (closed best-effort) to force a
+        clean reconnect on the next call rather than reusing a poisoned session.
+        """
+        try:
+            connection.rollback()
+        except Exception as exc:
+            logger.debug("rollback failed; discarding connection: %s", exc)
+            self._discard_connection()
+
+    def execute_write(self, sql: str, params: tuple[Any, ...] | None = None) -> int:
+        """Execute a single DML statement in an atomic transaction.
+
+        Commits on success and returns the affected-row count. On any failure the
+        transaction is rolled back (and the connection discarded if the rollback
+        itself fails), the full error is logged to stderr, and a sanitized
+        :class:`DatabaseError` is raised. Only reachable via the opt-in write
+        path; callers must have already passed :func:`safety.ensure_write_allowed`.
+        """
+        with self._lock:
+            connection = self.connect()
+            cursor = connection.cursor()
+            timed_out = False
+            try:
+                cursor.execute(sql, params or ())
+                affected = int(cursor.rowcount)
+                connection.commit()
+                return affected
+            except Exception as exc:
+                if _is_timeout_error(exc):
+                    # The socket is dead mid-statement; a rollback would only
+                    # block again. _timeout_error discards the connection.
+                    timed_out = True
+                    raise self._timeout_error(exc) from exc
+                self._rollback_or_discard(connection)
+                logger.error("write failed", exc_info=exc)
+                raise DatabaseError(f"write failed: {sanitize_error(exc)}") from exc
+            finally:
+                if not timed_out:
+                    self._safe_close_cursor(cursor)
+
     def _timeout_error(self, exc: BaseException) -> QueryTimeoutError:
         """Discard the corrupt connection and build a clear timeout error."""
         # The socket timed out mid-statement, so the connection buffer is now

--- a/cubrid_mcp_server/safety.py
+++ b/cubrid_mcp_server/safety.py
@@ -22,6 +22,13 @@ READ_ONLY_KEYWORDS: frozenset[str] = frozenset(
     {"SELECT", "SHOW", "DESC", "DESCRIBE", "EXPLAIN", "WITH"}
 )
 
+# Statements permitted in opt-in write mode (CUBRID_MCP_WRITE=1). Deliberately
+# limited to single-statement DML: DDL is excluded because CUBRID auto-commits
+# DDL, which defeats rollback and widens the blast radius. This whitelist is
+# only ever consulted on the explicitly-gated write path; the read-only default
+# path (:func:`ensure_read_only`) is untouched.
+WRITE_KEYWORDS: frozenset[str] = frozenset({"INSERT", "UPDATE", "DELETE"})
+
 # Keywords that mutate data/schema or otherwise escape read-only mode. Even when a
 # statement begins with an allowed keyword (e.g. a CTE ``WITH ... AS (...) DELETE`` or
 # a ``SELECT ... FOR UPDATE``), the presence of any of these anywhere in the token
@@ -92,6 +99,37 @@ def ensure_read_only(sql: str) -> None:
     forbidden = _forbidden_keywords(statement)
     if forbidden:
         raise UnsafeSQLError(f"{sorted(forbidden)[0]} is not permitted in read-only mode")
+
+
+def ensure_write_allowed(sql: str) -> None:
+    """Raise :class:`UnsafeSQLError` unless ``sql`` is a single write statement.
+
+    Only consulted on the opt-in write path (``CUBRID_MCP_WRITE=1``). Accepts a
+    single ``INSERT``/``UPDATE``/``DELETE`` statement; rejects everything else
+    (reads, DDL, transaction-control, multi-statement, and empty input) so that
+    enabling write mode cannot smuggle in DDL or read escapes. The read-only
+    default path (:func:`ensure_read_only`) is intentionally left unchanged.
+    """
+    if not sql or not sql.strip():
+        raise UnsafeSQLError("empty SQL statement")
+
+    sql = _strip_comments(sql)
+
+    statements = [stmt for stmt in sqlparse.parse(sql) if _is_non_empty(stmt)]
+    if len(statements) == 0:
+        raise UnsafeSQLError("empty SQL statement")
+    if len(statements) > 1:
+        raise UnsafeSQLError("multi-statement SQL is not allowed in write mode")
+
+    statement = statements[0]
+    keyword = _leading_keyword(statement)
+    if keyword is None:
+        raise UnsafeSQLError("could not determine the leading SQL keyword")
+    if keyword.upper() not in WRITE_KEYWORDS:
+        raise UnsafeSQLError(
+            f"{keyword.upper()} is not permitted in write mode; "
+            f"allowed statements: {', '.join(sorted(WRITE_KEYWORDS))}"
+        )
 
 
 def _is_non_empty(statement: Statement) -> bool:

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 import sys
 import threading
 from typing import Any
 
 from fastmcp import FastMCP
 
-from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.config import Config, ConfigError, _parse_bool
 from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database, sanitize_error
-from cubrid_mcp_server.safety import ensure_read_only
+from cubrid_mcp_server.safety import ensure_read_only, ensure_write_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +326,46 @@ def execute_query(sql: str) -> dict[str, Any]:
 def health_check() -> dict[str, Any]:
     """Check database connectivity on demand and report server status."""
     return _db().health_check()
+
+
+def _write_mode_requested() -> bool:
+    """Whether opt-in write mode is enabled, read from the environment.
+
+    Checked once at import to decide whether ``execute_write`` is registered as
+    an MCP tool at all: when disabled the tool is absent from capability
+    discovery, so there is no reachable write path. Call-time enforcement via
+    ``config.write_enabled`` provides defence in depth.
+    """
+    return _parse_bool(os.environ.get("CUBRID_MCP_WRITE", "0"))
+
+
+def execute_write(sql: str) -> dict[str, Any]:
+    """Execute a single write statement (INSERT/UPDATE/DELETE) atomically.
+
+    Only registered when ``CUBRID_MCP_WRITE`` is enabled. The statement runs in
+    an explicit transaction: it commits on success and rolls back on any error,
+    returning the number of affected rows. DDL, reads, and multi-statement input
+    are rejected by :func:`ensure_write_allowed`.
+    """
+    config = _cfg()
+    if not config.write_enabled:
+        # Defence in depth: the tool is normally not registered when write mode
+        # is off, but refuse regardless if somehow reached.
+        raise ValueError("write mode is disabled (set CUBRID_MCP_WRITE=1 to enable)")
+    if len(sql) > config.max_sql_length:
+        raise ValueError(
+            f"SQL exceeds maximum length of {config.max_sql_length} characters "
+            f"(CUBRID_MCP_MAX_SQL_LENGTH)"
+        )
+    ensure_write_allowed(sql)
+    affected = _db().execute_write(sql)
+    return {"affected_rows": affected}
+
+
+# Register the write tool only when write mode is enabled at startup, so a
+# read-only deployment never exposes a write path in MCP capability discovery.
+if _write_mode_requested():
+    mcp.tool(execute_write)
 
 
 def _render_rows(rows: list[tuple[Any, ...]], max_chars: int) -> dict[str, Any]:

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -335,8 +335,16 @@ def _write_mode_requested() -> bool:
     an MCP tool at all: when disabled the tool is absent from capability
     discovery, so there is no reachable write path. Call-time enforcement via
     ``config.write_enabled`` provides defence in depth.
+
+    Fails closed: an invalid ``CUBRID_MCP_WRITE`` value must not raise at import
+    time (which would bypass ``main()``'s clean ConfigError handling and break
+    tool introspection). The same value is re-validated by ``Config.from_env``,
+    which surfaces the error consistently through ``main()``.
     """
-    return _parse_bool(os.environ.get("CUBRID_MCP_WRITE", "0"))
+    try:
+        return _parse_bool(os.environ.get("CUBRID_MCP_WRITE", "0"))
+    except ConfigError:
+        return False
 
 
 def execute_write(sql: str) -> dict[str, Any]:

--- a/tests/test_write_mode.py
+++ b/tests/test_write_mode.py
@@ -1,0 +1,355 @@
+"""Unit tests for opt-in write mode + transaction management (issue #123).
+
+Covers the security invariant (read-only stays the default; the write path is
+unreachable unless explicitly enabled), the DML-only write whitelist, the
+atomic-transaction semantics of ``Database.execute_write`` (commit on success,
+rollback on failure, connection discard when rollback itself fails), and the
+conditional registration of the ``execute_write`` MCP tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import socket
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+import pycubrid
+from cubrid_mcp_server import server
+from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.context import AppContext
+from cubrid_mcp_server.database import Database, DatabaseError, QueryTimeoutError
+from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only, ensure_write_allowed
+
+_BASE = Config(
+    host="h",
+    port=33000,
+    user="u",
+    password="",
+    database="d",
+    readonly=True,
+    max_chars=4000,
+    max_rows=1000,
+)
+
+
+def _env(**extra: str) -> dict[str, str]:
+    base = {
+        "CUBRID_HOST": "h",
+        "CUBRID_USER": "u",
+        "CUBRID_PASSWORD": "p",
+        "CUBRID_DATABASE": "d",
+    }
+    base.update(extra)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Config parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_write_disabled_by_default() -> None:
+    assert Config.from_env(_env()).write_enabled is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "on", "yes", "TRUE"])
+def test_write_enabled_via_env(value: str) -> None:
+    assert Config.from_env(_env(CUBRID_MCP_WRITE=value)).write_enabled is True
+
+
+def test_write_invalid_value_raises() -> None:
+    with pytest.raises(ConfigError):
+        Config.from_env(_env(CUBRID_MCP_WRITE="maybe"))
+
+
+# --------------------------------------------------------------------------- #
+# safety.ensure_write_allowed — DML whitelist
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "INSERT INTO t VALUES (1)",
+        "UPDATE t SET a = 1 WHERE id = 2",
+        "DELETE FROM t WHERE id = 1",
+        "  insert into t values (1)  ",
+        "/* leading comment */ UPDATE t SET a = 1",
+    ],
+)
+def test_write_allows_single_dml(sql: str) -> None:
+    ensure_write_allowed(sql)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        "WITH c AS (SELECT 1) SELECT * FROM c",
+        "EXPLAIN SELECT 1",
+        "SHOW TABLES",
+        "CREATE TABLE t (a int)",
+        "ALTER TABLE t ADD b int",
+        "DROP TABLE t",
+        "TRUNCATE TABLE t",
+        "REPLACE INTO t VALUES (1)",
+        "MERGE INTO t USING s ON (t.id = s.id) WHEN MATCHED THEN UPDATE SET t.a = s.a",
+        "CALL some_proc()",
+        "COMMIT",
+        "ROLLBACK",
+        "GRANT SELECT ON t TO u",
+    ],
+)
+def test_write_blocks_non_dml(sql: str) -> None:
+    with pytest.raises(UnsafeSQLError):
+        ensure_write_allowed(sql)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "",
+        "   ",
+        "-- just a comment",
+        "/* only a block comment */",
+        "INSERT INTO t VALUES (1); DELETE FROM t",
+    ],
+)
+def test_write_blocks_empty_and_multi_statement(sql: str) -> None:
+    with pytest.raises(UnsafeSQLError):
+        ensure_write_allowed(sql)
+
+
+def test_read_only_path_unchanged_still_blocks_dml() -> None:
+    # The default security path is untouched: DML is still rejected there.
+    with pytest.raises(UnsafeSQLError):
+        ensure_read_only("INSERT INTO t VALUES (1)")
+
+
+def test_write_path_blocks_reads() -> None:
+    with pytest.raises(UnsafeSQLError):
+        ensure_write_allowed("SELECT * FROM t")
+
+
+# --------------------------------------------------------------------------- #
+# Database.execute_write — atomic transaction semantics
+# --------------------------------------------------------------------------- #
+
+
+class _WCursor:
+    def __init__(self, rowcount: int, execute_error: BaseException | None) -> None:
+        self.rowcount = rowcount
+        self._execute_error = execute_error
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.closed = False
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+        self.executed.append((sql, params))
+        if self._execute_error is not None:
+            raise self._execute_error
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _WConnection:
+    def __init__(
+        self,
+        *,
+        rowcount: int = 1,
+        execute_error: BaseException | None = None,
+        commit_error: BaseException | None = None,
+        rollback_error: BaseException | None = None,
+    ) -> None:
+        self._rowcount = rowcount
+        self._execute_error = execute_error
+        self._commit_error = commit_error
+        self._rollback_error = rollback_error
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+        self.cursors: list[_WCursor] = []
+
+    def cursor(self) -> _WCursor:
+        cur = _WCursor(self._rowcount, self._execute_error)
+        self.cursors.append(cur)
+        return cur
+
+    def commit(self) -> None:
+        if self._commit_error is not None:
+            raise self._commit_error
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+        if self._rollback_error is not None:
+            raise self._rollback_error
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _db_with(
+    monkeypatch: pytest.MonkeyPatch, **conn_kwargs: Any
+) -> tuple[Database, list[_WConnection]]:
+    conns: list[_WConnection] = []
+
+    def _connect(**_kwargs: Any) -> _WConnection:
+        conn = _WConnection(**conn_kwargs)
+        conns.append(conn)
+        return conn
+
+    monkeypatch.setattr(pycubrid, "connect", _connect)
+    return Database(_BASE), conns
+
+
+def test_execute_write_commits_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    db, conns = _db_with(monkeypatch, rowcount=5)
+    assert db.execute_write("INSERT INTO t VALUES (1)") == 5
+    assert conns[0].committed is True
+    assert conns[0].rolled_back is False
+    assert conns[0].cursors[0].closed is True
+
+
+def test_execute_write_rolls_back_on_execute_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    db, conns = _db_with(monkeypatch, execute_error=ValueError("boom"))
+    with pytest.raises(DatabaseError, match="write failed"):
+        db.execute_write("INSERT INTO t VALUES (1)")
+    assert conns[0].rolled_back is True
+    assert conns[0].committed is False
+
+
+def test_execute_write_rolls_back_on_commit_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    db, conns = _db_with(monkeypatch, commit_error=RuntimeError("commit fail"))
+    with pytest.raises(DatabaseError, match="write failed"):
+        db.execute_write("UPDATE t SET a = 1")
+    assert conns[0].rolled_back is True
+    assert conns[0].committed is False
+
+
+def test_execute_write_discards_connection_on_rollback_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db, conns = _db_with(
+        monkeypatch,
+        execute_error=ValueError("boom"),
+        rollback_error=RuntimeError("rollback fail"),
+    )
+    with pytest.raises(DatabaseError):
+        db.execute_write("DELETE FROM t WHERE id = 1")
+    # Rollback failed, so the poisoned connection is discarded (closed)...
+    assert conns[0].closed is True
+    # ...and the next call transparently reconnects.
+    db.connect()
+    assert len(conns) == 2
+
+
+def test_execute_write_timeout_discards_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    db, conns = _db_with(monkeypatch, execute_error=socket.timeout())
+    with pytest.raises(QueryTimeoutError):
+        db.execute_write("INSERT INTO t VALUES (1)")
+    assert conns[0].closed is True
+
+
+# --------------------------------------------------------------------------- #
+# server.execute_write tool behaviour
+# --------------------------------------------------------------------------- #
+
+
+class _FakeWriteDB:
+    def __init__(self, affected: int = 1) -> None:
+        self.affected = affected
+        self.writes: list[str] = []
+
+    def execute_write(self, sql: str, params: tuple[Any, ...] | None = None) -> int:
+        self.writes.append(sql)
+        return self.affected
+
+    def fetch_many(
+        self,
+        sql: str,
+        params: tuple[Any, ...] | None = None,
+        max_rows: int | None = None,
+    ) -> tuple[list[tuple[Any, ...]], bool]:
+        return [], False
+
+
+def _inject(monkeypatch: pytest.MonkeyPatch, db: _FakeWriteDB, **cfg: Any) -> None:
+    config = replace(_BASE, **cfg)
+    monkeypatch.setattr(server, "_context", AppContext(config=config, database=db))
+
+
+def test_execute_write_refuses_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _FakeWriteDB()
+    _inject(monkeypatch, db)  # write_enabled defaults False
+    with pytest.raises(ValueError, match="write mode is disabled"):
+        server.execute_write("INSERT INTO t VALUES (1)")
+    assert db.writes == []
+
+
+def test_execute_write_runs_dml_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _FakeWriteDB(affected=3)
+    _inject(monkeypatch, db, write_enabled=True)
+    assert server.execute_write("INSERT INTO t VALUES (1)") == {"affected_rows": 3}
+    assert db.writes == ["INSERT INTO t VALUES (1)"]
+
+
+def test_execute_write_blocks_non_dml_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _FakeWriteDB()
+    _inject(monkeypatch, db, write_enabled=True)
+    with pytest.raises(UnsafeSQLError):
+        server.execute_write("SELECT * FROM t")
+    assert db.writes == []
+
+
+def test_execute_write_rejects_over_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _FakeWriteDB()
+    _inject(monkeypatch, db, write_enabled=True, max_sql_length=10)
+    with pytest.raises(ValueError, match="exceeds maximum length"):
+        server.execute_write("INSERT INTO t VALUES (1234567890)")
+    assert db.writes == []
+
+
+def test_execute_query_stays_read_only_in_write_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Enabling write mode must NOT open a write path through execute_query.
+    db = _FakeWriteDB()
+    _inject(monkeypatch, db, write_enabled=True, readonly=True)
+    with pytest.raises(UnsafeSQLError):
+        server.execute_query("INSERT INTO t VALUES (1)")
+
+
+# --------------------------------------------------------------------------- #
+# Conditional tool registration (security invariant)
+# --------------------------------------------------------------------------- #
+
+
+def _tool_names(module: Any) -> set[str]:
+    return {tool.name for tool in asyncio.run(module.mcp.list_tools())}
+
+
+def test_write_tool_absent_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+    module = importlib.reload(server)
+    try:
+        names = _tool_names(module)
+        assert "execute_write" not in names
+        assert len(names) == 11
+    finally:
+        monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+        importlib.reload(server)
+
+
+def test_write_tool_registered_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CUBRID_MCP_WRITE", "1")
+    module = importlib.reload(server)
+    try:
+        names = _tool_names(module)
+        assert "execute_write" in names
+        assert len(names) == 12
+    finally:
+        monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+        importlib.reload(server)

--- a/tests/test_write_mode.py
+++ b/tests/test_write_mode.py
@@ -353,3 +353,17 @@ def test_write_tool_registered_when_enabled(monkeypatch: pytest.MonkeyPatch) -> 
     finally:
         monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
         importlib.reload(server)
+
+
+def test_write_tool_absent_on_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An invalid CUBRID_MCP_WRITE must not raise at import time (which would
+    # bypass main()'s clean ConfigError handling); it fails closed instead.
+    monkeypatch.setenv("CUBRID_MCP_WRITE", "maybe")
+    module = importlib.reload(server)
+    try:
+        names = _tool_names(module)
+        assert "execute_write" not in names
+        assert len(names) == 11
+    finally:
+        monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+        importlib.reload(server)


### PR DESCRIPTION
## Summary

Implements **#123** — opt-in write mode, the last of the v0.3.x epic (#23).

Write access stays **disabled by default**. Setting `CUBRID_MCP_WRITE=1` registers a separate `execute_write` MCP tool that runs a **single** `INSERT`/`UPDATE`/`DELETE` statement inside an explicit transaction (commit on success, rollback on any error, returns affected-row count). When write mode is off the tool is **not registered at all**, so no write path appears in MCP capability discovery; a defence-in-depth `config.write_enabled` check guards the call path too.

## Design (Oracle-reviewed: design APPROVE-WITH-CHANGES → post-impl APPROVE)

- **Separate DML-only whitelist** (`safety.ensure_write_allowed`) rejects standalone reads, DDL, transaction-control, and multi-statement input. The read-only default path (`ensure_read_only`) is untouched.
- **DDL intentionally unsupported** — CUBRID auto-commits DDL, which would defeat the rollback guarantee.
- **`execute_query` stays read-only** regardless of the write flag.
- **Atomic transaction** in `Database.execute_write`: serializes on the shared connection lock; on rollback failure the poisoned connection is discarded to force a clean reconnect; timeout is treated as unknown socket state and discarded.
- **Conditional registration** + call-time `write_enabled` check = airtight against accidental exposure.
- Errors logged in full to stderr; surfaced to clients sanitized (class name only).

## Tests

45 new tests in `tests/test_write_mode.py`: config parsing, whitelist allow/block matrix, read-only-path-unchanged, transaction semantics (commit / rollback-on-execute-error / rollback-on-commit-error / discard-on-rollback-failure / timeout-discard), server-level behavior, and conditional registration (11 tools disabled vs 12 enabled).

Full suite: 212 passed, coverage 98.25% (floor 95%). ruff + ruff format + mypy clean.

## Docs

Updated in the same PR: README (tool table + `CUBRID_MCP_WRITE` config row + "Write mode (opt-in)" section), SECURITY.md ("Layer 2b — opt-in write mode"), CHANGELOG (`[Unreleased]` Added + Security).