### PR TITLE
fix: make execute_write and per-connection write/audit knobs connection-aware (#136, #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `execute_write` now honours the per-call `connection` argument instead of always writing to the `default` connection, matching the read tools and the v0.3.0 multi-connection contract. (#136)
+- Per-connection `CUBRID_<NAME>_MCP_WRITE` and `CUBRID_<NAME>_MCP_AUDIT_LOG` settings are now actually applied: write-enablement is enforced against the *target* connection's config (a connection with writes off refuses even when another enables them), the `execute_write` tool is registered whenever **any** connection opts into write mode, and audit logging is resolved per connection so a named connection's `MCP_AUDIT_LOG` takes effect independently of the default. `execute_write` calls are now audited as well. (#137)
+
 ## [0.3.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Optional settings:
 | `CUBRID_MCP_MAX_ROWS` | `1000` | Max rows returned by `execute_query` before truncation |
 | `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
 | `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
-| `CUBRID_MCP_AUDIT_LOG` | `0` | Opt-in audit logging. When enabled, emits one redaction-safe JSON record per executed statement (`execute_query`/`explain_query`) to **stderr** — see [Logging](#logging). |
+| `CUBRID_MCP_AUDIT_LOG` | `0` | Opt-in audit logging. When enabled, emits one redaction-safe JSON record per executed statement (`execute_query`/`explain_query`/`execute_write`) to **stderr** — see [Logging](#logging). Honoured per connection (`CUBRID_<NAME>_MCP_AUDIT_LOG`). |
+| `CUBRID_MCP_WRITE` | `0` | Opt-in write mode. When enabled (`1`), registers the `execute_write` tool for single-statement DML. Honoured per connection (`CUBRID_<NAME>_MCP_WRITE`); the tool is registered when any connection enables it. Off by default. |
 | `CUBRID_MCP_WRITE` | `0` | Opt-in write mode. When enabled (`1`), registers the `execute_write` tool for single-statement DML. Off by default. |
 
 ### Multiple connections
@@ -219,12 +220,13 @@ For production use, also configure a read-only database user. See [`SECURITY.md`
 
 ### Write mode (opt-in)
 
-Write access is **disabled by default**. Setting `CUBRID_MCP_WRITE=1` registers an additional `execute_write` tool that accepts a **single** `INSERT`, `UPDATE`, or `DELETE` statement and runs it in an explicit transaction (commit on success, rollback on any error). When write mode is off the tool is not registered at all, so no write path is exposed in MCP capability discovery.
+Write access is **disabled by default**. Setting `CUBRID_MCP_WRITE=1` registers an additional `execute_write` tool that accepts a **single** `INSERT`, `UPDATE`, or `DELETE` statement and runs it in an explicit transaction (commit on success, rollback on any error). When write mode is off the tool is not registered at all, so no write path is exposed in MCP capability discovery. With multiple connections configured, the tool is registered when **any** connection enables writes (via `CUBRID_MCP_WRITE` or `CUBRID_<NAME>_MCP_WRITE`).
 
 Constraints and rationale:
 
 - **Single-statement DML only.** Standalone reads, DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`), transaction-control, and multi-statement input are rejected. (A single DML statement may still legally contain subqueries, e.g. `INSERT ... SELECT`.)
 - **DDL is intentionally unsupported.** CUBRID auto-commits DDL, which defeats the rollback guarantee, so it is excluded from write mode.
+- **Write mode is per-connection.** `execute_write` accepts the same optional `connection` argument as the read tools and runs against that connection; a connection whose `CUBRID_<NAME>_MCP_WRITE` is off refuses the write even when another connection enables it.
 - `execute_query` remains **read-only regardless** of the write-mode flag.
 - Enforcement is defense-in-depth; still run the server as a CUBRID user granted only the privileges it needs. See [`SECURITY.md`](./SECURITY.md).
 
@@ -236,11 +238,11 @@ Errors surfaced back to the LLM client are **sanitized**: only the exception cat
 
 ### Audit logging (opt-in)
 
-Set `CUBRID_MCP_AUDIT_LOG=1` to record every executed statement (`execute_query` and `explain_query`) as a single structured JSON line on **stderr**. It is **off by default**. Each record is redaction-safe and contains only:
+Set `CUBRID_MCP_AUDIT_LOG=1` to record every executed statement (`execute_query`, `explain_query`, and `execute_write`) as a single structured JSON line on **stderr**. It is **off by default** and honoured **per connection** — a named connection sets `CUBRID_<NAME>_MCP_AUDIT_LOG` independently of the default. Each record is redaction-safe and contains only:
 
 | Field | Description |
 |-------|-------------|
-| `tool` | The MCP tool that ran the statement (`execute_query` / `explain_query`). |
+| `tool` | The MCP tool that ran the statement (`execute_query` / `explain_query` / `execute_write`). |
 | `status` | `ok` or `error`. |
 | `category` | The leading SQL keyword only (e.g. `SELECT`, `WITH`) — never the full statement. |
 | `identifiers` | Table names extracted after `FROM`/`JOIN` via a strict identifier regex; anything that is not a bare identifier (values, literals, expressions) is dropped. |

--- a/cubrid_mcp_server/context.py
+++ b/cubrid_mcp_server/context.py
@@ -35,23 +35,37 @@ class AppContext:
     registry: ConnectionRegistry
     databases: Mapping[str, Database]
     audit: AuditLogger | None = None
+    audits: Mapping[str, AuditLogger] | None = None
 
     def __post_init__(self) -> None:
-        # Derive a disabled/enabled audit logger from the default connection's
-        # config when one is not explicitly injected, so every context always
-        # has a usable ``audit``.
+        # Build a per-connection audit logger so each named connection honours
+        # its own MCP_AUDIT_LOG setting (#137). When an explicit default
+        # ``audit`` is injected (tests/callers) it is reused for the default
+        # slot so existing behaviour and spies are preserved.
+        if self.audits is None:
+            audits: dict[str, AuditLogger] = {}
+            for name, cfg in self.registry.configs.items():
+                if name == self.registry.default_name and self.audit is not None:
+                    audits[name] = self.audit
+                else:
+                    audits[name] = AuditLogger(cfg.audit_log)
+            object.__setattr__(self, "audits", audits)
+        else:
+            audits = dict(self.audits)
         if self.audit is None:
-            object.__setattr__(self, "audit", AuditLogger(self.registry.config_for().audit_log))
+            object.__setattr__(self, "audit", audits[self.registry.default_name])
 
     @classmethod
     def from_env(cls) -> "AppContext":
         """Build a context and its databases from environment configuration."""
         registry = ConnectionRegistry.from_env()
         databases = {name: Database(config) for name, config in registry.configs.items()}
+        audits = {name: AuditLogger(config.audit_log) for name, config in registry.configs.items()}
         return cls(
             registry=registry,
             databases=databases,
-            audit=AuditLogger(registry.config_for().audit_log),
+            audit=audits[registry.default_name],
+            audits=audits,
         )
 
     @classmethod
@@ -69,6 +83,21 @@ class AppContext:
     def config_for(self, connection: str | None = None) -> Config:
         """Return the :class:`Config` for ``connection`` (default when ``None``)."""
         return self.registry.config_for(connection)
+
+    def audit_for(self, connection: str | None = None) -> AuditLogger:
+        """Return the :class:`AuditLogger` for ``connection`` (default when ``None``).
+
+        Validates the name through the registry first so an unknown connection
+        raises the same clear, client-safe error as :meth:`config_for`.
+        """
+        self.registry.config_for(connection)
+        name = (
+            connection.strip().lower()
+            if connection and connection.strip()
+            else self.registry.default_name
+        )
+        assert self.audits is not None  # __post_init__ always populates this
+        return self.audits[name]
 
     def database_for(self, connection: str | None = None) -> Database:
         """Return the :class:`Database` for ``connection`` (default when ``None``).

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -57,8 +57,8 @@ def _cfg(connection: str | None = None) -> Config:
     return _get_context().config_for(connection)
 
 
-def _audit() -> AuditLogger:
-    audit = _get_context().audit
+def _audit(connection: str | None = None) -> AuditLogger:
+    audit = _get_context().audit_for(connection)
     assert audit is not None  # AppContext.__post_init__ always populates this
     return audit
 
@@ -208,7 +208,7 @@ def list_indexes(table_name: str, connection: str | None = None) -> list[dict[st
 @mcp.tool
 def explain_query(sql: str, connection: str | None = None) -> dict[str, Any]:
     """Return CUBRID's execution plan/trace for a ``SELECT`` or ``WITH`` statement."""
-    with _audit().track("explain_query", sql):
+    with _audit(connection).track("explain_query", sql):
         cleaned = sql.strip().rstrip(";").strip()
         if not cleaned:
             raise ValueError("empty SQL statement")
@@ -327,7 +327,7 @@ def execute_query(sql: str, connection: str | None = None) -> dict[str, Any]:
     """Execute a read-only SQL statement and return rows, truncated if large."""
     db = _db(connection)
     config = _cfg(connection)
-    with _audit().track("execute_query", sql) as outcome:
+    with _audit(connection).track("execute_query", sql) as outcome:
         if len(sql) > config.max_sql_length:
             raise ValueError(
                 f"SQL exceeds maximum length of {config.max_sql_length} characters "
@@ -354,45 +354,74 @@ def health_check(connection: str | None = None) -> dict[str, Any]:
 
 
 def _write_mode_requested() -> bool:
-    """Whether opt-in write mode is enabled, read from the environment.
+    """Whether any connection opts into write mode, read from the environment.
 
     Checked once at import to decide whether ``execute_write`` is registered as
-    an MCP tool at all: when disabled the tool is absent from capability
-    discovery, so there is no reachable write path. Call-time enforcement via
-    ``config.write_enabled`` provides defence in depth.
+    an MCP tool at all: when no connection enables writes the tool is absent from
+    capability discovery, so there is no reachable write path. Per-call
+    enforcement via ``config.write_enabled`` (resolved for the *target*
+    connection) provides defence in depth and decides which connection may write.
 
-    Fails closed: an invalid ``CUBRID_MCP_WRITE`` value must not raise at import
-    time (which would bypass ``main()``'s clean ConfigError handling and break
-    tool introspection). The same value is re-validated by ``Config.from_env``,
-    which surfaces the error consistently through ``main()``.
+    Scans the default ``CUBRID_MCP_WRITE`` plus every ``CUBRID_<NAME>_MCP_WRITE``
+    named in ``CUBRID_CONNECTIONS`` (#137), so a deployment that enables writes on
+    a named connection only still exposes the tool. Reads only the write knobs
+    (not the connection fields), so it stays import-safe and never requires
+    ``CUBRID_HOST`` etc. to be present.
+
+    Fails closed: an invalid write value must not raise at import time (which
+    would bypass ``main()``'s clean ConfigError handling and break tool
+    introspection). The same values are re-validated by ``Config.from_env``,
+    which surfaces any error consistently through ``main()``.
     """
-    try:
-        return _parse_bool(os.environ.get("CUBRID_MCP_WRITE", "0"))
-    except ConfigError:
-        return False
+    env = os.environ
+    prefixes = ["CUBRID_"]
+    raw = env.get("CUBRID_CONNECTIONS", "").strip()
+    if raw:
+        for part in raw.split(","):
+            name = part.strip()
+            if name:
+                prefixes.append(f"CUBRID_{name.upper()}_")
+    for prefix in prefixes:
+        try:
+            if _parse_bool(env.get(f"{prefix}MCP_WRITE", "0")):
+                return True
+        except ConfigError:
+            # Fail closed on this connection's invalid value; main() re-validates.
+            continue
+    return False
 
 
-def execute_write(sql: str) -> dict[str, Any]:
+def execute_write(sql: str, connection: str | None = None) -> dict[str, Any]:
     """Execute a single write statement (INSERT/UPDATE/DELETE) atomically.
 
-    Only registered when ``CUBRID_MCP_WRITE`` is enabled. The statement runs in
-    an explicit transaction: it commits on success and rolls back on any error,
-    returning the number of affected rows. DDL, reads, and multi-statement input
-    are rejected by :func:`ensure_write_allowed`.
+    Only registered when at least one connection enables ``CUBRID_MCP_WRITE``. The
+    statement runs against the *selected* connection in an explicit transaction:
+    it commits on success and rolls back on any error, returning the number of
+    affected rows. DDL, reads, and multi-statement input are rejected by
+    :func:`ensure_write_allowed`. Write-enablement is enforced per connection, so
+    a connection whose ``MCP_WRITE`` is off refuses even when another enables it.
     """
-    config = _cfg()
-    if not config.write_enabled:
-        # Defence in depth: the tool is normally not registered when write mode
-        # is off, but refuse regardless if somehow reached.
-        raise ValueError("write mode is disabled (set CUBRID_MCP_WRITE=1 to enable)")
-    if len(sql) > config.max_sql_length:
-        raise ValueError(
-            f"SQL exceeds maximum length of {config.max_sql_length} characters "
-            f"(CUBRID_MCP_MAX_SQL_LENGTH)"
-        )
-    ensure_write_allowed(sql)
-    affected = _db().execute_write(sql)
-    return {"affected_rows": affected}
+    config = _cfg(connection)
+    db = _db(connection)
+    with _audit(connection).track("execute_write", sql) as outcome:
+        if not config.write_enabled:
+            # Defence in depth: the tool is normally not registered when no
+            # connection enables write mode, but refuse regardless if the target
+            # connection has writes disabled.
+            raise ValueError(
+                "write mode is disabled for this connection "
+                "(set CUBRID_MCP_WRITE=1, or CUBRID_<NAME>_MCP_WRITE=1 for a "
+                "named connection, to enable)"
+            )
+        if len(sql) > config.max_sql_length:
+            raise ValueError(
+                f"SQL exceeds maximum length of {config.max_sql_length} characters "
+                f"(CUBRID_MCP_MAX_SQL_LENGTH)"
+            )
+        ensure_write_allowed(sql)
+        affected = db.execute_write(sql)
+        outcome.row_count = affected
+        return {"affected_rows": affected}
 
 
 # Register the write tool only when write mode is enabled at startup, so a

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -121,3 +121,38 @@ def test_close_closes_all_even_when_one_fails() -> None:
         ctx.close()
     # The second database is still closed despite the first raising.
     assert sorted(closed) == ["failing", "ok"]
+
+
+def test_audit_for_is_per_connection() -> None:
+    from dataclasses import replace
+
+    default_cfg = replace(_TEST_CONFIG, audit_log=False)
+    reporting_cfg = replace(_REPORTING_CONFIG, audit_log=True)
+    registry = ConnectionRegistry(configs={"default": default_cfg, "reporting": reporting_cfg})
+    ctx = AppContext(
+        registry=registry,
+        databases={"default": object(), "reporting": object()},  # type: ignore[dict-item]
+    )
+    # Each connection honours its own MCP_AUDIT_LOG (#137).
+    assert ctx.audit_for().enabled is False
+    assert ctx.audit_for("reporting").enabled is True
+    # Selection is case-insensitive and whitespace-tolerant, matching database_for.
+    assert ctx.audit_for("  REPORTING ").enabled is True
+    # The default audit attribute points at the default connection's logger.
+    assert ctx.audit is ctx.audit_for()
+
+
+def test_audit_for_unknown_connection_raises() -> None:
+    ctx = AppContext.single(config=_TEST_CONFIG, database=object())  # type: ignore[arg-type]
+    with pytest.raises(ConfigError) as excinfo:
+        ctx.audit_for("nope")
+    assert "unknown connection" in str(excinfo.value)
+
+
+def test_injected_audit_is_reused_for_default_slot() -> None:
+    from cubrid_mcp_server.audit import AuditLogger
+
+    injected = AuditLogger(False)
+    ctx = AppContext.single(config=_TEST_CONFIG, database=object(), audit=injected)  # type: ignore[arg-type]
+    assert ctx.audit is injected
+    assert ctx.audit_for() is injected

--- a/tests/test_write_mode.py
+++ b/tests/test_write_mode.py
@@ -19,7 +19,7 @@ import pytest
 
 import pycubrid
 from cubrid_mcp_server import server
-from cubrid_mcp_server.config import Config, ConfigError
+from cubrid_mcp_server.config import Config, ConfigError, ConnectionRegistry, DEFAULT_CONNECTION
 from cubrid_mcp_server.context import AppContext
 from cubrid_mcp_server.database import Database, DatabaseError, QueryTimeoutError
 from cubrid_mcp_server.safety import UnsafeSQLError, ensure_read_only, ensure_write_allowed
@@ -356,6 +356,112 @@ def test_write_tool_registered_when_enabled(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_write_tool_absent_on_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An invalid CUBRID_MCP_WRITE must not raise at import time (which would
+    # bypass main()'s clean ConfigError handling); it fails closed instead.
+    monkeypatch.setenv("CUBRID_MCP_WRITE", "maybe")
+    module = importlib.reload(server)
+    try:
+        names = _tool_names(module)
+        assert "execute_write" not in names
+        assert len(names) == 11
+    finally:
+        monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+        importlib.reload(server)
+
+
+# --------------------------------------------------------------------------- #
+# Multi-connection write routing + per-connection enablement (#136, #137)
+# --------------------------------------------------------------------------- #
+
+
+def _multi_inject(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    default_cfg: Config,
+    default_db: _FakeWriteDB,
+    named_cfg: Config,
+    named_db: _FakeWriteDB,
+    named: str = "reporting",
+) -> None:
+    registry = ConnectionRegistry(
+        configs={DEFAULT_CONNECTION: default_cfg, named: named_cfg},
+        default_name=DEFAULT_CONNECTION,
+    )
+    ctx = AppContext(
+        registry=registry,
+        databases={DEFAULT_CONNECTION: default_db, named: named_db},  # type: ignore[dict-item]
+    )
+    monkeypatch.setattr(server, "_context", ctx)
+
+
+def test_execute_write_routes_to_selected_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    # #136: execute_write must honour the per-call ``connection`` argument
+    # instead of always using the default connection.
+    default_db = _FakeWriteDB(affected=1)
+    named_db = _FakeWriteDB(affected=7)
+    _multi_inject(
+        monkeypatch,
+        default_cfg=replace(_BASE, write_enabled=True),
+        default_db=default_db,
+        named_cfg=replace(_BASE, write_enabled=True),
+        named_db=named_db,
+    )
+    result = server.execute_write("INSERT INTO t VALUES (1)", connection="reporting")
+    assert result == {"affected_rows": 7}
+    assert named_db.writes == ["INSERT INTO t VALUES (1)"]
+    assert default_db.writes == []
+
+
+def test_execute_write_refuses_when_target_connection_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #137: write-enablement is enforced per connection. The default may enable
+    # writes while a named connection keeps them off (and vice versa).
+    default_db = _FakeWriteDB()
+    named_db = _FakeWriteDB()
+    _multi_inject(
+        monkeypatch,
+        default_cfg=replace(_BASE, write_enabled=True),
+        default_db=default_db,
+        named_cfg=replace(_BASE, write_enabled=False),
+        named_db=named_db,
+    )
+    with pytest.raises(ValueError, match="write mode is disabled"):
+        server.execute_write("INSERT INTO t VALUES (1)", connection="reporting")
+    assert named_db.writes == []
+    # The default connection, which does enable writes, still works.
+    assert server.execute_write("INSERT INTO t VALUES (1)") == {"affected_rows": 1}
+    assert default_db.writes == ["INSERT INTO t VALUES (1)"]
+
+
+def test_write_mode_requested_true_for_named_connection_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #137: the write tool must be registered when a *named* connection enables
+    # writes, even if the default connection does not.
+    monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+    monkeypatch.setenv("CUBRID_CONNECTIONS", "reporting")
+    monkeypatch.setenv("CUBRID_REPORTING_MCP_WRITE", "1")
+    assert server._write_mode_requested() is True
+
+
+def test_write_mode_requested_false_when_none_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+    monkeypatch.setenv("CUBRID_CONNECTIONS", "reporting")
+    monkeypatch.delenv("CUBRID_REPORTING_MCP_WRITE", raising=False)
+    assert server._write_mode_requested() is False
+
+
+def test_write_mode_requested_fails_closed_on_invalid_named(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An invalid named write value must not raise at import time; it fails closed.
+    monkeypatch.delenv("CUBRID_MCP_WRITE", raising=False)
+    monkeypatch.setenv("CUBRID_CONNECTIONS", "reporting")
+    monkeypatch.setenv("CUBRID_REPORTING_MCP_WRITE", "maybe")
+    assert server._write_mode_requested() is False
     # An invalid CUBRID_MCP_WRITE must not raise at import time (which would
     # bypass main()'s clean ConfigError handling); it fails closed instead.
     monkeypatch.setenv("CUBRID_MCP_WRITE", "maybe")


### PR DESCRIPTION
## Summary

Fixes two multi-connection correctness gaps found in the Oracle cross-verification review of v0.3.0.

### #136 — `execute_write` ignored the per-call `connection`
`execute_write` always used the default `_cfg()`/`_db()`, contradicting the v0.3.0 multi-connection claim. It now accepts the same optional `connection` argument as the read tools and resolves config/db/audit for that connection.

### #137 — per-connection `MCP_WRITE` / `MCP_AUDIT_LOG` were parsed but ignored
- **Write enablement** is now enforced against the *target* connection's config: a connection with `CUBRID_<NAME>_MCP_WRITE` off refuses even when another enables it.
- **Tool registration** (`_write_mode_requested`) now scans `CUBRID_MCP_WRITE` plus every `CUBRID_<NAME>_MCP_WRITE` named in `CUBRID_CONNECTIONS`, so a named-connection-only write deployment still exposes the tool. It reads only the write knobs (import-safe, fails closed on invalid values).
- **Audit logging** is resolved per connection via the new `AppContext.audit_for()`; each named connection honours its own `CUBRID_<NAME>_MCP_AUDIT_LOG`. `execute_write` calls are now audited too.

## Invariants preserved
- Read-only default path untouched; `execute_query` stays read-only regardless of write mode.
- DML-only write whitelist and atomic-transaction semantics unchanged.
- All audit output stays on **stderr** (per-connection loggers share the existing non-propagating stderr handler).

## Testing
- `pytest -m "not integration"` → **269 passed** (+8 new: multi-connection write routing, per-connection write refusal, `_write_mode_requested` env scan, per-connection `audit_for`).
- `ruff check` clean. `mypy` clean apart from a pre-existing `pycubrid` stub import note on the untouched `database.py` (present on `main`).

## Docs
README write-mode + audit-logging sections and the env-var table updated for the per-connection behaviour; CHANGELOG entry added.

Closes #136
Closes #137