### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-02
+
 ### Fixed
 - `execute_write` now honours the per-call `connection` argument instead of always writing to the `default` connection, matching the read tools and the v0.3.0 multi-connection contract. (#136)
 - Per-connection `CUBRID_<NAME>_MCP_WRITE` and `CUBRID_<NAME>_MCP_AUDIT_LOG` settings are now actually applied: write-enablement is enforced against the *target* connection's config (a connection with writes off refuses even when another enables them), the `execute_write` tool is registered whenever **any** connection opts into write mode, and audit logging is resolved per connection so a named connection's `MCP_AUDIT_LOG` takes effect independently of the default. `execute_write` calls are now audited as well. (#137)

--- a/cubrid_mcp_server/__init__.py
+++ b/cubrid_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Model Context Protocol server for CUBRID database."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## Summary
- Bump `cubrid_mcp_server.__version__` to `0.3.1`
- Promote the Unreleased CHANGELOG entries under a dated `## [0.3.1] - 2026-09-02` heading

## Release
Merging this PR then publishing a GitHub Release `v0.3.1` will trigger `publish-pypi.yml` to build, verify, and publish to PyPI.