### PR TITLE
release: v0.4.0 — PyPI availability, docs site, Beta status

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material pymdown-extensions
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -18,3 +18,19 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
       - run: pytest -m "not integration" -q
+
+  # fastmcp 4.x is a major rewrite (MCP SDK v2, sessionless protocol). The
+  # dependency pin stays >=3.0,<4; this canary collects evidence for the
+  # eventual migration decision instead of discovering breakage at release time.
+  fastmcp-canary:
+    name: Test against fastmcp@latest
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pip install --force-reinstall "fastmcp@latest"
+      - run: pytest -m "not integration" -q

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ htmlcov/
 # CUBRID artifacts
 *.log
 cubrid_*.log
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-09
+
+### Added
+- Published to PyPI: `uvx cubrid-mcp-server` and `pipx run cubrid-mcp-server` now install from PyPI instead of a git checkout.
+- Documentation site (mkdocs-material) deployed to https://cubrid-lab.github.io/cubrid-mcp-server/ — quickstart, full tool reference, security model, multi-connection guide, and troubleshooting.
+- Korean README translation (`docs/README.ko.md`), matching the sibling repositories' translation set.
+- `upstream-canary.yml` now also tracks `fastmcp@latest` in addition to `pycubrid@main`, giving the eventual fastmcp 4.x migration decision CI evidence. The dependency pin intentionally remains `>=3.0,<4` until that canary is green.
+- Official MCP Registry readiness: PyPI ownership-verification marker (`mcp-name: io.github.cubrid-lab/cubrid-mcp-server`) embedded in README, and `glama.json` added at the repo root for Glama registry indexing.
+
+### Changed
+- Development Status classifier raised from `2 - Pre-Alpha` to `4 - Beta`: the server has shipped multi-database connections, opt-in write mode, audit logging, Resources, and Prompts since 0.3.0.
+- `[project.urls]` now includes `Documentation` and `Changelog` links, matching the sibling repositories.
+- `Framework :: AsyncIO` trove classifier added for registry/search discoverability.
+
+### Fixed
+- README: removed a duplicated `CUBRID_MCP_WRITE` row in the configuration table.
+
 ## [0.3.1] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation site (mkdocs-material) deployed to https://cubrid-lab.github.io/cubrid-mcp-server/ — quickstart, full tool reference, security model, multi-connection guide, and troubleshooting.
 - Korean README translation (`docs/README.ko.md`), matching the sibling repositories' translation set.
 - `upstream-canary.yml` now also tracks `fastmcp@latest` in addition to `pycubrid@main`, giving the eventual fastmcp 4.x migration decision CI evidence. The dependency pin intentionally remains `>=3.0,<4` until that canary is green.
+- `THIRD_PARTY_LICENSES.md` (full runtime license inventory, pip-licenses generated) and a `NOTICE` file (original implementation, no third-party code embedded) added.
 - Official MCP Registry readiness: PyPI ownership-verification marker (`mcp-name: io.github.cubrid-lab/cubrid-mcp-server`) embedded in README, and `glama.json` added at the repo root for Glama registry indexing.
 
 ### Changed

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+cubrid-mcp-server
+Copyright (c) 2025 Yeongseon Choe
+
+This product is licensed under the MIT License (see LICENSE).
+
+This package is an original implementation. It contains no third-party
+source code and embeds no third-party assets. Runtime dependencies and
+their licenses are enumerated in THIRD_PARTY_LICENSES.md.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](https://www.cubrid.org/), enabling LLMs to safely inspect schemas and execute read-only queries via [pycubrid](https://pypi.org/project/pycubrid/).
 
+<!-- mcp-name: io.github.cubrid-lab/cubrid-mcp-server -->
+
 ## Features
 
 | Tool | Description |
@@ -72,7 +74,6 @@ Optional settings:
 | `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds. If the server sends no data within this window the query is aborted and the connection is reset. This is a socket read timeout, not a true server-side statement timeout. |
 | `CUBRID_MCP_AUDIT_LOG` | `0` | Opt-in audit logging. When enabled, emits one redaction-safe JSON record per executed statement (`execute_query`/`explain_query`/`execute_write`) to **stderr** — see [Logging](#logging). Honoured per connection (`CUBRID_<NAME>_MCP_AUDIT_LOG`). |
 | `CUBRID_MCP_WRITE` | `0` | Opt-in write mode. When enabled (`1`), registers the `execute_write` tool for single-statement DML. Honoured per connection (`CUBRID_<NAME>_MCP_WRITE`); the tool is registered when any connection enables it. Off by default. |
-| `CUBRID_MCP_WRITE` | `0` | Opt-in write mode. When enabled (`1`), registers the `execute_write` tool for single-statement DML. Off by default. |
 
 ### Multiple connections
 
@@ -119,19 +120,7 @@ Notes:
 
 ### Run
 
-> **Note:** The package is not yet published to PyPI. Until the first release lands, install and run it from source (see [Development](#development)); the `uvx`/`pipx` commands below will work once the package is available on PyPI.
-
-### Run from source (available now)
-
-```bash
-git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
-cd cubrid-mcp-server
-python -m venv .venv && source .venv/bin/activate
-pip install -e .
-cubrid-mcp-server
-```
-
-### Run from PyPI (once published)
+### Run from PyPI
 
 Use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to run directly from PyPI:
 
@@ -143,6 +132,16 @@ Or with `pipx`:
 
 ```bash
 pipx run cubrid-mcp-server
+```
+
+### Run from source
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cubrid-mcp-server
 ```
 
 ## MCP Client Integration

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,90 @@
+# Third-Party Software Licenses
+
+This file lists the third-party open-source software used by **cubrid-mcp-server** (runtime dependency tree, generated with `pip-licenses`).
+
+All listed dependencies are distributed under permissive licenses (MIT, BSD-2/3-Clause, Apache-2.0, ISC, PSF, MPL-2.0, Unlicense). No dependency is copyleft/GPL, and none conflicts with this project's MIT license. The single MPL-2.0 package (`certifi`) is a file-level-licensed data bundle distributed unmodified.
+
+Direct runtime dependencies: `fastmcp>=3.0,<4` (Apache-2.0), `pycubrid>=1.4,<2` (MIT), `sqlparse>=0.5,<1` (BSD). Everything else below is pulled in transitively by `fastmcp`.
+
+## Runtime dependencies
+
+| Name                      | Version   | License                              | URL                                                                                |
+|---------------------------|-----------|--------------------------------------|------------------------------------------------------------------------------------|
+| aiofile                   | 3.9.0     | Apache Software License              | http://github.com/mosquito/aiofile                                                 |
+| jsonschema-path           | 0.5.0     | Apache Software License              | https://github.com/p1c2u/jsonschema-path                                           |
+| pathable                  | 0.6.0     | Apache Software License              | https://github.com/p1c2u/pathable                                                  |
+| caio                      | 0.9.25    | Apache-2.0                           | UNKNOWN                                                                            |
+| cyclopts                  | 4.25.2    | Apache-2.0                           | https://github.com/BrianPugh/cyclopts                                              |
+| fastmcp                   | 3.4.7     | Apache-2.0                           | https://gofastmcp.com                                                              |
+| fastmcp-slim              | 3.4.7     | Apache-2.0                           | https://gofastmcp.com                                                              |
+| importlib_metadata        | 9.0.1     | Apache-2.0                           | https://github.com/python/importlib_metadata                                       |
+| opentelemetry-api         | 1.44.0    | Apache-2.0                           | https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api |
+| py-key-value-aio          | 0.4.5     | Apache-2.0                           | UNKNOWN                                                                            |
+| python-multipart          | 0.0.32    | Apache-2.0                           | https://github.com/Kludex/python-multipart                                         |
+| packaging                 | 26.3      | Apache-2.0 OR BSD-2-Clause           | https://github.com/pypa/packaging                                                  |
+| cryptography              | 50.0.1    | Apache-2.0 OR BSD-3-Clause           | https://github.com/pyca/cryptography                                               |
+| Authlib                   | 1.8.0     | BSD License                          | https://github.com/authlib/authlib                                                 |
+| httpx                     | 0.28.1    | BSD License                          | https://github.com/encode/httpx                                                    |
+| joserfc                   | 1.7.5     | BSD License                          | https://github.com/authlib/joserfc                                                 |
+| pyperclip                 | 1.11.0    | BSD License                          | https://github.com/asweigart/pyperclip                                                        |
+| sqlparse                  | 0.6.0     | BSD License                          | https://github.com/andialbrecht/sqlparse                                           |
+| Pygments                  | 2.21.0    | BSD-2-Clause                         | https://pygments.org                                                               |
+| SecretStorage             | 3.5.0     | BSD-3-Clause                         | https://github.com/mitya57/secretstorage                                           |
+| click                     | 8.5.0     | BSD-3-Clause                         | https://github.com/pallets/click/                                                  |
+| httpcore                  | 1.6.0     | BSD-3-Clause                         | https://www.encode.io/httpcore/                                                    |
+| idna                      | 3.19      | BSD-3-Clause                         | https://github.com/kjd/idna                                                        |
+| pycparser                 | 3.0       | BSD-3-Clause                         | https://github.com/eliben/pycparser                                                |
+| python-dotenv             | 1.2.3     | BSD-3-Clause                         | https://github.com/theskumar/python-dotenv                                         |
+| sse-starlette             | 3.4.11    | BSD-3-Clause                         | https://github.com/sysid/sse-starlette                                             |
+| starlette                 | 1.6.0     | BSD-3-Clause                         | https://github.com/Kludex/starlette                                                |
+| uvicorn                   | 0.52.4    | BSD-3-Clause                         | https://uvicorn.dev/                                                               |
+| websockets                | 16.1.1    | BSD-3-Clause                         | https://github.com/python-websockets/websockets                                    |
+| griffelib                 | 2.3.0     | ISC                                  | UNKNOWN                                                                            |
+| dnspython                 | 2.8.0     | ISC License (ISCL)                   | https://www.dnspython.org                                                          |
+| PyJWT                     | 2.13.0    | MIT                                  | https://github.com/jpadilla/pyjwt                                                  |
+| annotated-types           | 0.8.0     | MIT                                  | https://github.com/annotated-types/annotated-types                                 |
+| anyio                     | 4.15.1    | MIT                                  | https://anyio.readthedocs.io/en/stable/versionhistory.html                         |
+| attrs                     | 26.1.0    | MIT                                  | https://www.attrs.org/en/stable/changelog.html                                     |
+| cachetools                | 7.1.8     | MIT                                  | https://github.com/tkem/cachetools/                                                |
+| httpx-sse                 | 0.4.3     | MIT                                  | https://github.com/florimondmanca/httpx-sse                                        |
+| jaraco.context            | 6.1.2     | MIT                                  | https://github.com/jaraco/jaraco.context                                           |
+| jaraco.functools          | 4.6.0     | MIT                                  | https://github.com/jaraco/jaraco.functools                                         |
+| jeepney                   | 0.9.0     | MIT                                  | https://gitlab.com/takluyver/jeepney                                              |
+| jsonref                   | 1.1.0     | MIT                                  | https://github.com/gazpachoking/jsonref                                            |
+| jsonschema                | 4.26.0    | MIT                                  | https://github.com/python-jsonschema/jsonschema                                    |
+| jsonschema-specifications | 2025.9.1  | MIT                                  | https://github.com/python-jsonschema/jsonschema-specifications                     |
+| keyring                   | 25.7.0    | MIT                                  | https://github.com/jaraco/keyring                                                  |
+| more-itertools            | 11.1.0    | MIT                                  | https://github.com/more-itertools/more-itertools                                   |
+| pycubrid                  | 1.7.0     | MIT                                  | https://github.com/cubrid-lab/pycubrid                                             |
+| pydantic                  | 2.13.5    | MIT                                  | https://github.com/pydantic/pydantic                                               |
+| pydantic-settings         | 2.15.0    | MIT                                  | https://github.com/pydantic/pydantic-settings                                      |
+| pydantic_core             | 2.46.5    | MIT                                  | https://github.com/pydantic/pydantic                                               |
+| referencing               | 0.37.0    | MIT                                  | https://github.com/python-jsonschema/referencing                                   |
+| rich-rst                  | 2.1.0     | MIT                                  | https://wasi-master.github.io/rich-rst                                             |
+| rpds-py                   | 0.30.0    | MIT                                  | https://github.com/crate-py/rpds                                                   |
+| typing-inspection         | 0.4.4     | MIT                                  | https://github.com/pydantic/typing-inspection                                      |
+| zipp                      | 4.1.0     | MIT                                  | https://github.com/jaraco/zipp                                                     |
+| PyYAML                    | 6.0.3     | MIT License                          | https://pyyaml.org/                                                                |
+| backports.tarfile         | 1.2.0     | MIT License                          | https://github.com/jaraco/backports.tarfile                                        |
+| beartype                  | 0.22.9    | MIT License                          | UNKNOWN                                                                            |
+| docstring_parser          | 0.18.0    | MIT License                          | https://github.com/rr-/docstring_parser                                            |
+| exceptiongroup            | 1.3.1     | MIT License                          | https://github.com/agronholm/exceptiongroup/blob/main/CHANGES.rst                  |
+| h11                       | 0.16.0    | MIT License                          | https://github.com/python-hyper/h11                                                |
+| jaraco.classes            | 3.4.0     | MIT License                          | https://github.com/jaraco/jaraco.classes                                           |
+| markdown-it-py            | 4.2.0     | MIT License                          | https://github.com/executablebooks/markdown-it-py                                  |
+| mcp                       | 1.30.0    | MIT License                          | https://modelcontextprotocol.io                                                    |
+| mdurl                     | 0.1.2     | MIT License                          | https://github.com/executablebooks/mdurl                                           |
+| openapi-pydantic          | 0.5.1     | MIT License                          | https://github.com/mike-oakley/openapi-pydantic                                    |
+| rich                      | 15.0.0    | MIT License                          | https://github.com/Textualize/rich                                                 |
+| uncalled-for              | 0.4.0     | MIT License                          | https://github.com/chrisguidry/uncalled-for                                        |
+| watchfiles                | 1.2.0     | MIT License                          | https://github.com/samuelcolvin/watchfiles                                         |
+| cffi                      | 2.1.1     | MIT-0                                | https://cffi.readthedocs.io/en/latest/whatsnew.html                                |
+| certifi                   | 2026.7.22 | Mozilla Public License 2.0 (MPL 2.0) | https://github.com/certifi/python-certifi                                          |
+| typing_extensions         | 4.16.0    | PSF-2.0                              | https://github.com/python/typing_extensions                                        |
+| email-validator           | 2.3.0     | The Unlicense (Unlicense)            | https://github.com/JoshData/python-email-validator                                 |
+
+(The `cubrid-mcp-server` row emitted by pip-licenses is omitted — it is this project.)
+
+## Development / test-only dependencies
+
+Not distributed with the package: `pytest`, `pytest-asyncio`, `pytest-cov`, `ruff`, `mypy`, `pre-commit`, `tox` (all MIT/Apache-2.0).

--- a/cubrid_mcp_server/__init__.py
+++ b/cubrid_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Model Context Protocol server for CUBRID database."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/docs/MULTI_CONNECTION.md
+++ b/docs/MULTI_CONNECTION.md
@@ -1,0 +1,65 @@
+# Multi-Connection
+
+One server process can serve several CUBRID databases. Every tool accepts an optional `connection` argument selecting the target; single-database setups are unchanged.
+
+## Default connection
+
+The bare `CUBRID_*` variables define a single connection named `default`:
+
+```bash
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+```
+
+## Named connections
+
+List extra connection names in `CUBRID_CONNECTIONS` (comma-separated) and provide `CUBRID_<NAME>_*` variables for each:
+
+```bash
+# Default connection (unchanged)
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+
+# Additional named connections
+export CUBRID_CONNECTIONS=reporting,analytics
+
+export CUBRID_REPORTING_HOST=reporting-db
+export CUBRID_REPORTING_USER=readonly_user
+export CUBRID_REPORTING_PASSWORD=secret
+export CUBRID_REPORTING_DATABASE=reports
+export CUBRID_REPORTING_MCP_MAX_ROWS=500   # optional per-connection tuning
+
+export CUBRID_ANALYTICS_HOST=analytics-db
+export CUBRID_ANALYTICS_USER=readonly_user
+export CUBRID_ANALYTICS_PASSWORD=secret
+export CUBRID_ANALYTICS_DATABASE=analytics
+```
+
+Then, in a client conversation: *"Query the analytics database for …"* — the model passes `connection="analytics"` to the tool.
+
+## Rules
+
+- Connection names must match `[A-Za-z0-9_]+` and are matched case-insensitively.
+- `default` is reserved (it always comes from the bare `CUBRID_*` variables) and cannot appear in `CUBRID_CONNECTIONS`.
+- For a named connection `<NAME>`, connection fields live at `CUBRID_<NAME>_HOST` etc., and the optional tuning knobs at `CUBRID_<NAME>_MCP_*` (the same suffixes as the global ones).
+- Named connections do **not** inherit values from the bare variables — specify every field for each named connection.
+- Selecting an unknown connection returns a clear error listing the available names.
+
+## Per-connection isolation
+
+Each connection is independently configured and enforced:
+
+| Setting | Per-connection variable | Effect |
+|---------|------------------------|--------|
+| Read-only | `CUBRID_<NAME>_MCP_READONLY` | Whitelist enforcement for this connection only |
+| Write mode | `CUBRID_<NAME>_MCP_WRITE` | Opt-in `execute_write` for this connection only |
+| Audit log | `CUBRID_<NAME>_MCP_AUDIT_LOG` | Audit stream for this connection only |
+| Output limits | `CUBRID_<NAME>_MCP_MAX_ROWS` / `_MAX_CHARS` / `_MAX_SQL_LENGTH` / `_QUERY_TIMEOUT` | Tuning for this connection only |
+
+Each connection also has its own lock, connection lifecycle, and stale-connection recovery, so a hung query on one database does not block the others.
+
+Write-mode registration nuance: the `execute_write` tool appears in MCP capability discovery when **any** connection enables writes, but every call is enforced against the **target** connection's setting — a connection with writes off refuses the write even when another connection enables them. See the [Security Model](SECURITY_MODEL.md#layer-2b-opt-in-write-mode-cubrid_mcp_write).

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,248 @@
+# cubrid-mcp-server (한국어)
+
+> 영어 원문: [README.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/README.md)
+
+[CUBRID](https://www.cubrid.org/) 데이터베이스를 위한 [Model Context Protocol](https://modelcontextprotocol.io) 서버. LLM 클라이언트가 순수 Python 드라이버 [pycubrid](https://pypi.org/project/pycubrid/)를 통해 스키마를 안전하게 조회하고 **읽기 전용** 쿼리를 실행할 수 있습니다.
+
+## 기능
+
+| 도구 | 설명 |
+|------|------|
+| `all_table_names` | 데이터베이스의 모든 사용자 테이블 목록 |
+| `filter_table_names` | 테이블 이름 부분 문자열 검색 |
+| `schema_definitions` | 컬럼 타입, NULL 허용 여부, 기본값, 기본 키 정보 |
+| `describe_table` | 컬럼·기본 키·인덱스를 한 번에 조회 |
+| `list_indexes` | 테이블의 인덱스 (키 컬럼 및 플래그 포함) |
+| `explain_query` | `SELECT`/`WITH` 실행 계획 (CUBRID `SHOW TRACE`) |
+| `table_row_counts` | 한 개 이상 테이블의 `COUNT(*)` |
+| `list_serials` | CUBRID `SERIAL` 시퀀스 (현재값 및 범위) |
+| `list_class_hierarchy` | CUBRID `CLASS` 상속 관계 |
+| `execute_query` | 읽기 전용 SQL 실행 (출력 자동 잘림) |
+| `health_check` | 데이터베이스 연결 상태 확인 |
+| `execute_write` | 단일 `INSERT`/`UPDATE`/`DELETE`를 원자적 트랜잭션으로 실행 (**옵트인 쓰기 모드 활성화 시에만 등록**) |
+
+### 리소스 (Resources)
+
+스키마 메타데이터는 읽기 전용 [MCP Resources](https://modelcontextprotocol.io/docs/concepts/resources)로도 노출됩니다. 리소스는 도구와 동일한 읽기 전용 카탈로그 쿼리를 재사용하므로 데이터 접근 범위는 늘어나지 않습니다.
+
+| 리소스 URI | 설명 |
+|--------------|------|
+| `cubrid://schema` | 전체 스키마 인덱스 (모든 사용자 테이블과 개별 리소스 URI) |
+| `cubrid://schema/{table}` | 테이블별 메타데이터 (컬럼, 기본 키, 인덱스) — `describe_table`과 동일 |
+
+모두 `application/json`을 반환합니다.
+
+### 프롬프트 (Prompts)
+
+일반적인 조회 작업을 안내하는 **MCP 프롬프트 템플릿**도 제공합니다. 프롬프트는 **안내 전용**입니다 — 어떤 읽기 전용 도구를 어떤 순서로 호출할지 알려줄 뿐, 데이터베이스에 접근하거나 SQL을 실행하지 않으며, 전달된 인자는 신뢰할 수 없는 데이터로 취급됩니다.
+
+| 프롬프트 | 인자 | 설명 |
+|--------|------|------|
+| `summarize_table` | `table` | 테이블 설명 후 제한된 읽기 전용 쿼리로 샘플 조회 |
+| `explain_query` | `sql` | `SELECT`/`WITH` 실행 계획 해석 |
+| `inspect_schema` | (없음) | 읽기 전용 도구들로 전체 스키마 개요 작성 |
+| `find_index_candidates` | `table` | 테이블의 인덱스 커버리지 검토 |
+
+## 빠른 시작
+
+### 설정
+
+필수 환경 변수:
+
+```bash
+export CUBRID_HOST=localhost
+export CUBRID_PORT=33000        # 선택, 기본값: 33000
+export CUBRID_USER=readonly_user   # SELECT 권한만 가진 CUBRID 사용자 (보안 참고)
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+```
+
+선택 설정:
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `CUBRID_MCP_READONLY` | `1` | 읽기 전용 SQL 화이트리스트 강제 |
+| `CUBRID_MCP_MAX_CHARS` | `4000` | 쿼리 출력 최대 글자 수 |
+| `CUBRID_MCP_MAX_ROWS` | `1000` | `execute_query` 최대 행 수 (초과 시 잘림) |
+| `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | 제출 가능한 SQL 최대 길이 (글자 수) |
+| `CUBRID_MCP_QUERY_TIMEOUT` | `30` | 문장별 소켓 읽기 타임아웃 (초). 서버가 이 시간 내에 데이터를 보내지 않으면 쿼리가 중단되고 연결이 재설정됩니다. 서버 측 문장 타임아웃이 아닙니다. |
+| `CUBRID_MCP_AUDIT_LOG` | `0` | 옵트인 감사 로그. 활성화 시 실행된 문장마다 재던션-safe JSON 기록을 **stderr**에 출력 (연결별 적용: `CUBRID_<NAME>_MCP_AUDIT_LOG`) |
+| `CUBRID_MCP_WRITE` | `0` | 옵트인 쓰기 모드. `1`로 설정하면 단일 DML용 `execute_write` 도구가 등록됩니다 (연결별 적용: `CUBRID_<NAME>_MCP_WRITE`). 기본은 꺼짐 |
+
+### 다중 연결
+
+기본적으로 `CUBRID_*` 변수만으로 `default`라는 이름의 단일 연결이 구성됩니다. `CUBRID_CONNECTIONS`(쉼표 구분)에 추가 연결 이름을 나열하고 각각 `CUBRID_<NAME>_*` 변수를 제공하면 하나의 프로세스에서 여러 CUBRID 데이터베이스를 서빙할 수 있습니다. 모든 도구는 선택적 `connection` 인자를 받으며, 생략하면 `default` 연결을 사용하므로 기존 설정은 그대로 유지됩니다.
+
+```bash
+# 기본 연결 (기존과 동일)
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+
+# 추가 이름 있는 연결들
+export CUBRID_CONNECTIONS=reporting,analytics
+
+export CUBRID_REPORTING_HOST=reporting-db
+export CUBRID_REPORTING_USER=readonly_user
+export CUBRID_REPORTING_PASSWORD=secret
+export CUBRID_REPORTING_DATABASE=reports
+export CUBRID_REPORTING_MCP_MAX_ROWS=500   # 연결별 선택 튜닝
+```
+
+참고: 연결 이름은 `[A-Za-z0-9_]+` 형식이며 대소문자를 구분하지 않습니다. `default`는 예약된 이름입니다. 이름 있는 연결은 기본 변수를 상속하지 않으므로 모든 필드를 지정해야 합니다. 연결별로 읽기 전용 강제가 독립적으로 적용됩니다.
+
+### 실행
+
+PyPI에서 [`uvx`](https://docs.astral.sh/uv/guides/tools/)로 바로 실행:
+
+```bash
+uvx cubrid-mcp-server
+```
+
+또는 `pipx`로:
+
+```bash
+pipx run cubrid-mcp-server
+```
+
+소스에서 실행:
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cubrid-mcp-server
+```
+
+## MCP 클라이언트 연동
+
+### Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+프로젝트 루트의 `.mcp.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+`.cursor/mcp.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+## 보안
+
+서버는 기본적으로 **읽기 전용**입니다. 코드 수준의 SQL 화이트리스트는 `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH` 문만 허용하며, 다중 문장 쿼리는 거부됩니다.
+
+> **SQL 화이트리스트는 심층 방어이지 보안 경계가 아닙니다.** 명백한 실수를 막는 파서 기반 가드레일일 뿐, 실제 강제 계층은 데이터베이스 자체입니다. 모델이 읽을 수 있는 테이블에 **SELECT 권한만 가진 CUBRID 사용자**로 서버를 실행하세요. 자세한 내용은 [`SECURITY.md`](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/SECURITY.md)를 참고하세요.
+
+### 쓰기 모드 (옵트인)
+
+쓰기 접근은 **기본적으로 비활성화**됩니다. `CUBRID_MCP_WRITE=1`을 설정하면 단일 `INSERT`/`UPDATE`/`DELETE` 문을 명시적 트랜잭션(성공 시 커밋, 오류 시 롤백)으로 실행하는 `execute_write` 도구가 등록됩니다. 쓰기 모드가 꺼져 있으면 도구 자체가 등록되지 않아 MCP 기능 탐색에 쓰기 경로가 노출되지 않습니다.
+
+제약 사항:
+
+- **단일 DML 문만 허용.** 독립 실행형 읽기, DDL(`CREATE`/`ALTER`/`DROP`/`TRUNCATE`), 트랜잭션 제어, 다중 문장 입력은 거부됩니다. (단일 DML 안의 서브쿼리는 합법적으로 허용됩니다.)
+- **DDL은 의도적으로 미지원.** CUBRID는 DDL을 자동 커밋하므로 롤백 보장이 무의미해집니다.
+- **쓰기 모드는 연결 단위.** 읽기 도구와 동일한 `connection` 인자를 받으며, 대상 연결의 설정으로 강제됩니다.
+- `execute_query`는 쓰기 모드 플래그와 무관하게 **항상 읽기 전용**입니다.
+
+## 로깅
+
+서버는 MCP **stdio 전송**을 사용하며 `stdout`은 JSON-RPC 프로토콜 스트림으로 예약됩니다. **모든 로그는 `stderr`로 출력**되며, 로그 레벨 기본값은 `INFO`입니다. LLM 클라이언트에 반환되는 오류는 **재던션 처리**됩니다 — 예외 카테고리(예: `query failed: OperationalError`)만 반환되고 전체 세부 정보는 운영자를 위해 stderr에 기록됩니다. 스키마 세부 사항, 호스트명, SQL 조각, 설정 값이 클라이언트에 노출되지 않습니다.
+
+### 감사 로깅 (옵트인)
+
+`CUBRID_MCP_AUDIT_LOG=1`을 설정하면 실행된 모든 문장(`execute_query`, `explain_query`, `execute_write`)에 대해 **stderr**에 구조화된 JSON 한 줄이 기록됩니다. 기본은 꺼짐이며 연결별로 적용됩니다.
+
+| 필드 | 설명 |
+|-------|------|
+| `tool` | 문장을 실행한 MCP 도구 |
+| `status` | `ok` 또는 `error` |
+| `category` | 선행 SQL 키워드만 (예: `SELECT`, `WITH`) — 전체 문장은 절대 기록 안 함 |
+| `identifiers` | `FROM`/`JOIN` 뒤에서 식별자 정규식으로 추출한 테이블 이름. 식별자가 아닌 것(값, 리터럴, 표현식)은 버려짐 |
+| `sql_length` | 제출된 SQL의 글자 수 |
+| `row_count`, `truncated` | 결과 크기 및 잘림 여부 (성공 시만) |
+| `duration_ms` | 호출 소요 시간 (정수 밀리초) |
+| `error_type` | 실패 시 예외 클래스 이름만 |
+
+**원본 SQL 텍스트, 바인드 파라미터, 리터럴 값은 절대 기록되지 않습니다.**
+
+## 개발
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+
+# 린트 및 타입 검사
+ruff check .
+mypy cubrid_mcp_server
+
+# 단위 테스트
+pytest -m "not integration"
+
+# 통합 테스트 (실행 중인 CUBRID 필요)
+export CUBRID_HOST=localhost CUBRID_USER=dba CUBRID_PASSWORD="" CUBRID_DATABASE=demodb
+pytest -m integration
+```
+
+## 고지
+
+> 이 프로젝트는 CUBRID 개발자 도구를 위한 독립 오픈소스 이니셔티브인 [CUBRID Lab](https://github.com/cubrid-lab)의 일부이며, CUBRID Corporation 또는 공식 CUBRID 프로젝트와 제휴, 후원, 보증 관계가 없습니다.
+
+## 라이선스
+
+MIT ([`LICENSE`](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/LICENSE) 참고).

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -1,0 +1,66 @@
+# Security Model
+
+`cubrid-mcp-server` bridges a CUBRID database and any MCP-speaking LLM client. Treat every query coming from the model as untrusted input: the LLM may hallucinate destructive SQL, and a malicious prompt may try to exfiltrate data the server was never meant to expose. Defence in depth is the design intent.
+
+## Layer 1 — database permissions (required)
+
+Run the server as a dedicated CUBRID user that has **only the privileges you want the model to use**. The code-level safety checker is not a substitute for this.
+
+```sql
+-- 1. Create the user
+CREATE USER mcp_reader PASSWORD 'replace-me';
+
+-- 2. Grant SELECT only on the specific tables you want exposed.
+--    CUBRID grants privileges per table (there is no schema-wide db.* grant).
+GRANT SELECT ON customers TO mcp_reader;
+GRANT SELECT ON orders TO mcp_reader;
+-- ...repeat for each table the model may read.
+
+-- 3. Do NOT grant CREATE, ALTER, DROP, INSERT, UPDATE, DELETE, GRANT, or any DBA role.
+```
+
+Additional hardening: use a long random password from a secret manager, rotate it on your normal cadence, grant per-table rather than schema-wide, and keep CUBRID on a network only the MCP-server host can reach. See [`SECURITY.md`](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/SECURITY.md) for the full policy.
+
+## Layer 2 — read-only SQL whitelist
+
+The server is **read-only by default**. When `CUBRID_MCP_READONLY=1` (the default), every statement is parsed with `sqlparse` and rejected unless it is `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, or `WITH` (CTE). Multi-statement input is rejected outright, so a trailing `; DROP TABLE …` cannot slip through.
+
+> The whitelist is defense-in-depth, not a security boundary. It is a parser-based guardrail against obvious mistakes; the real enforcement layer is the database itself (Layer 1).
+
+`CUBRID_MCP_READONLY=0` disables this layer — only do so when the DB user is already read-only and you need statements the parser misclassifies. `explain_query` is **always** read-only regardless of this flag; only `execute_query` honors disabling it.
+
+## Layer 2b — opt-in write mode (`CUBRID_MCP_WRITE`)
+
+Write access is **off by default**. Setting `CUBRID_MCP_WRITE=1` registers a separate `execute_write` tool bounded by:
+
+- **DML only.** A dedicated whitelist (`ensure_write_allowed`) accepts a **single** `INSERT`, `UPDATE`, or `DELETE` and rejects standalone reads, DDL, transaction control, and multi-statement input. (A single DML statement may still legally embed subqueries, e.g. `INSERT ... SELECT`.)
+- **Atomic transactions.** The statement runs in an explicit transaction — commit on success, rollback on any failure.
+- **DDL is intentionally unsupported.** CUBRID auto-commits DDL, which would defeat the rollback guarantee, so `CREATE`/`ALTER`/`DROP`/`TRUNCATE` are never permitted.
+- **Not registered when disabled.** With write mode off, `execute_write` is absent from MCP capability discovery — there is no reachable write path, not merely a guarded one.
+- **Per-connection gating.** With multiple connections, the tool is registered when **any** connection enables writes, but each write is enforced against the **target** connection's setting — a connection with writes off refuses even when another enables them.
+- `execute_query` remains **read-only regardless** of the write flag.
+
+## Layer 3 — output limits
+
+`execute_query` caps rows at `CUBRID_MCP_MAX_ROWS` (default 1000) and truncates rendered output at `CUBRID_MCP_MAX_CHARS` (default 4000). This protects the model's context window and limits how much data a single probing query can exfiltrate. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large.
+
+## Layer 4 — audit logging (opt-in)
+
+Set `CUBRID_MCP_AUDIT_LOG=1` to emit one structured JSON record per executed statement (`execute_query`, `explain_query`, `execute_write`) on **stderr**. Off by default; honoured per connection (`CUBRID_<NAME>_MCP_AUDIT_LOG`).
+
+| Field | Description |
+|-------|-------------|
+| `tool` | The MCP tool that ran the statement |
+| `status` | `ok` or `error` |
+| `category` | The leading SQL keyword only (e.g. `SELECT`, `WITH`) — never the full statement |
+| `identifiers` | Table names extracted after `FROM`/`JOIN` via a strict identifier regex; anything that is not a bare identifier is dropped |
+| `sql_length` | Length of the submitted SQL, in characters |
+| `row_count`, `truncated` | Result size and whether output was truncated (success only) |
+| `duration_ms` | Wall-clock duration of the call, in integer milliseconds |
+| `error_type` | On failure, the exception class name only |
+
+The **raw SQL text, bound parameters, and literal values are never logged**, so secrets embedded in a query do not reach the audit stream.
+
+## Logging discipline
+
+The server speaks MCP stdio: `stdout` carries the JSON-RPC protocol stream, so **all logging is routed to stderr**. Errors surfaced to the LLM client are sanitized — only the exception category (e.g. `query failed: OperationalError`) is returned, while full detail goes to stderr for operators. This keeps schema details, hostnames, SQL fragments, and configuration values out of client-visible messages.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,92 @@
+# Tools Reference
+
+`cubrid-mcp-server` exposes its capabilities as MCP **tools**, **resources**, and **prompts**. Every tool accepts an optional `connection` argument (see [Multi-Connection](MULTI_CONNECTION.md)); omitting it targets the `default` connection.
+
+## Tools
+
+### Schema inspection
+
+#### `all_table_names(connection=None)`
+
+Lists every user table in the database. System and catalog tables are excluded.
+
+#### `filter_table_names(substring, connection=None)`
+
+Case-insensitive substring search over table names. Use this instead of `all_table_names` when the schema is large.
+
+#### `schema_definitions(table_name, connection=None)`
+
+Column-level metadata for one table: column name, type, nullability, default value, and primary-key membership.
+
+#### `describe_table(table_name, connection=None)`
+
+Full metadata for one table in a single call — columns, primary key, and indexes. Mirrors the `cubrid://schema/{table}` resource.
+
+#### `list_indexes(table_name, connection=None)`
+
+Indexes defined on a table, with the indexed key columns and flags (unique, reverse).
+
+#### `list_class_hierarchy(connection=None, ...)`
+
+CUBRID `CLASS` inheritance relationships — which tables inherit from which.
+
+### Querying
+
+#### `execute_query(sql, connection=None)`
+
+Runs **read-only** SQL (`SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH`). Output is automatically truncated to respect the model's context window:
+
+- at most `CUBRID_MCP_MAX_ROWS` rows (default 1000),
+- rendered output capped at `CUBRID_MCP_MAX_CHARS` characters (default 4000),
+- statement length capped at `CUBRID_MCP_MAX_SQL_LENGTH` (default 65536),
+- per-statement socket read timeout of `CUBRID_MCP_QUERY_TIMEOUT` seconds (default 30).
+
+Multi-statement input is rejected. Binary values are base64-encoded when small and summarized (`<binary N bytes>`) when large.
+
+#### `explain_query(sql, connection=None)`
+
+Returns the execution plan/trace for a `SELECT` or `WITH` statement via CUBRID `SHOW TRACE`. Always read-only, independent of the `CUBRID_MCP_READONLY` flag.
+
+#### `table_row_counts(connection=None, ...)`
+
+`COUNT(*)` for one table or many — cheaper than sampling rows to estimate size.
+
+### CUBRID specifics
+
+#### `list_serials(connection=None)`
+
+CUBRID `SERIAL` sequences with their current value, minimum, maximum, and increment.
+
+#### `health_check(connection=None)`
+
+Verifies database connectivity on demand and reports per-connection status. Useful after environment changes or long idle periods.
+
+### Opt-in writes
+
+#### `execute_write(sql, connection=None)`
+
+Runs a **single** `INSERT`, `UPDATE`, or `DELETE` statement in an explicit transaction (commit on success, rollback on any failure). **Registered only when write mode is enabled** (`CUBRID_MCP_WRITE=1` or `CUBRID_<NAME>_MCP_WRITE=1` on any connection) — with write mode off, the tool does not exist in MCP capability discovery at all.
+
+Constraints: DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`), standalone reads, transaction control, and multi-statement input are rejected. See the [Security Model](SECURITY_MODEL.md).
+
+## Resources
+
+Schema metadata is also exposed as read-only [MCP Resources](https://modelcontextprotocol.io/docs/concepts/resources), so clients can discover schema context without a tool call. Resources reuse the same read-only catalog queries — no additional data-access surface.
+
+| Resource URI | Description |
+|--------------|-------------|
+| `cubrid://schema` | Whole-schema index: every user table with its per-table resource URI |
+| `cubrid://schema/{table}` | Per-table metadata (columns, primary key, indexes) — mirrors `describe_table` |
+
+Both return `application/json`. Table names in `{table}` are percent-decoded by URI-template matching; an unknown or system table produces a resource-read error, matching the `describe_table` tool.
+
+## Prompts
+
+The server exposes MCP **Prompt templates** — guidance-only starting points for common inspection tasks. Each prompt returns text telling the client which read-only tools to call and in what order. Prompts never touch the database, execute SQL, or add any data-access surface, and arguments are fenced as untrusted data.
+
+| Prompt | Arguments | Description |
+|--------|-----------|-------------|
+| `summarize_table` | `table` | Describe a table, then sample it with a bounded read-only query |
+| `explain_query` | `sql` | Obtain and interpret a `SELECT`/`WITH` execution plan via `explain_query` |
+| `inspect_schema` | *(none)* | Build a high-level overview of the whole schema from the read-only tools |
+| `find_index_candidates` | `table` | Review a table's index coverage for potential review areas |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+Symptom → cause → fix for the most common problems.
+
+## The client cannot connect to the server
+
+**Symptom:** the MCP client shows the server as failed or unavailable.
+
+- **`uvx` not found.** The client launches `uvx cubrid-mcp-server` — install [uv](https://docs.astral.sh/uv/) so `uvx` is on the client's `PATH`, or use an absolute path in the client config (`"command": "/home/you/.local/bin/uvx"`).
+- **Environment variables missing.** `CUBRID_HOST`, `CUBRID_USER`, `CUBRID_PASSWORD`, and `CUBRID_DATABASE` must be present in the client's `env` block — a plain terminal export is not visible to GUI apps like Claude Desktop.
+- **Config file location.** Claude Desktop reads `~/Library/Application Support/Claude/claude_desktop_config.json`; Claude Code reads `.mcp.json` at the project root; Cursor reads `.cursor/mcp.json`. After editing, restart the client.
+
+## CUBRID connection refused
+
+**Symptom:** tools fail with connection or operational errors.
+
+- **Wrong port.** The server connects to the CUBRID **broker** on port 33000 (`CUBRID_PORT`), not the manager port 1523.
+- **Database does not exist.** Create it first (`cubrid createdb`) or point `CUBRID_DATABASE` at an existing database.
+- **CUBRID still starting.** A fresh CUBRID container takes a while to accept connections — the broker accepts TCP slightly after the engine is up. Wait for readiness (e.g. the docker-compose healthcheck) before starting queries. `health_check` verifies connectivity on demand.
+- **Credentials.** `CUBRID_USER`/`CUBRID_PASSWORD` must be valid; `dba` with an empty password is common in local docker setups.
+
+## Permission denied on queries
+
+**Symptom:** authorization errors on `SELECT` statements.
+
+The CUBRID user lacks grants. CUBRID grants privileges **per table** — there is no schema-wide `db.*` grant. Create a user and grant `SELECT` on each table the model may read; see the [Security Model](SECURITY_MODEL.md#layer-1-database-permissions-required).
+
+## Read-only rejection
+
+**Symptom:** `execute_query` rejects a statement.
+
+By design. The whitelist allows only `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, and `WITH`; multi-statement input is always rejected. If you truly need other statements, first put a read-only DB user in place, then consider `CUBRID_MCP_READONLY=0` — and for writes, use opt-in write mode instead of disabling the whitelist.
+
+## Output looks cut off
+
+**Symptom:** `execute_query` results end abruptly or report truncation.
+
+Row and character caps protect the model's context window. Raise `CUBRID_MCP_MAX_ROWS` (default 1000) or `CUBRID_MCP_MAX_CHARS` (default 4000) if you need more, or narrow the query.
+
+## Query timeout semantics
+
+**Symptom:** long-running queries abort after ~30s.
+
+`CUBRID_MCP_QUERY_TIMEOUT` (default 30) is a **socket read timeout**, not a true server-side statement timeout: if the server sends no data within the window, the query is aborted and the connection reset. Tune it per workload (and per connection via `CUBRID_<NAME>_MCP_QUERY_TIMEOUT`).
+
+## No logs anywhere / server output looks like JSON garbage
+
+The server speaks MCP stdio: `stdout` carries the protocol stream, and **all logging goes to stderr**. Look at the client's MCP log pane (or launch the server manually and redirect `2>server.log`). Never add `print()` to stdout in customizations — it corrupts the protocol stream and breaks the connection.
+
+## Audit log not appearing
+
+Set `CUBRID_MCP_AUDIT_LOG=1` (opt-in, off by default). With multiple connections, enable it per connection via `CUBRID_<NAME>_MCP_AUDIT_LOG`. Records are JSON lines on **stderr** — they never appear on stdout. See the [Security Model](SECURITY_MODEL.md#layer-4-audit-logging-opt-in).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# cubrid-mcp-server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for the [CUBRID](https://www.cubrid.org/) database. It lets LLM clients such as Claude Desktop, Claude Code, and Cursor safely inspect schemas and run **read-only** queries through the pure-Python [pycubrid](https://pypi.org/project/pycubrid/) driver.
+
+```bash
+uvx cubrid-mcp-server
+```
+
+## Why this server
+
+- **Read-only by default.** A code-level SQL whitelist allows only `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, and `WITH` statements; multi-statement input is rejected. Write access is a separate, opt-in tool.
+- **Schema-aware.** Twelve tools cover table discovery, column metadata, indexes, serials, class hierarchy, row counts, execution plans, and health checks — plus the same metadata as MCP Resources.
+- **Multi-database.** One server process can serve several CUBRID databases, each with independent read-only, write, and audit settings.
+- **Operations-friendly.** All logging goes to stderr (stdout is reserved for the MCP protocol stream), errors returned to the client are sanitized, and an opt-in audit log records every executed statement without ever logging raw SQL.
+
+## Tool surface
+
+| Tool | Description |
+|------|-------------|
+| `all_table_names` | List every user table in the database |
+| `filter_table_names` | Substring search over table names |
+| `schema_definitions` | Column types, nullability, defaults, and primary key info |
+| `describe_table` | Full metadata: columns, primary key, and indexes in one call |
+| `list_indexes` | Indexes for a table with key columns and flags |
+| `explain_query` | Execution plan/trace for a `SELECT`/`WITH` (via CUBRID `SHOW TRACE`) |
+| `table_row_counts` | `COUNT(*)` for one or many tables |
+| `list_serials` | CUBRID `SERIAL` sequences with current value and bounds |
+| `list_class_hierarchy` | CUBRID `CLASS` inheritance relationships |
+| `execute_query` | Run read-only SQL with automatic output truncation |
+| `health_check` | Verify database connectivity on demand |
+| `execute_write` | Single `INSERT`/`UPDATE`/`DELETE` in an atomic transaction (**only registered when opt-in write mode is enabled**) |
+
+See the full [Tools reference](TOOLS.md) for parameters and return shapes, the [Security Model](SECURITY_MODEL.md) for the safety design, and [Multi-Connection](MULTI_CONNECTION.md) for serving several databases from one process.
+
+## Documentation
+
+- [Quick Start](quickstart.md) — configure, run, and connect your first MCP client
+- [Tools](TOOLS.md) — the complete tool, resource, and prompt reference
+- [Security Model](SECURITY_MODEL.md) — read-only enforcement, opt-in writes, audit logging
+- [Multi-Connection](MULTI_CONNECTION.md) — named connections and per-connection settings
+- [Troubleshooting](TROUBLESHOOTING.md) — common problems and fixes
+- [한국어 문서](README.ko.md)
+
+## License
+
+MIT — see [LICENSE](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/LICENSE).
+
+> This project is part of [CUBRID Lab](https://github.com/cubrid-lab), an independent open-source initiative for CUBRID developer tooling, and is not affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,134 @@
+# Quick Start
+
+Run the CUBRID MCP server and connect an LLM client in a few minutes.
+
+## 1. Configure
+
+Set the required environment variables:
+
+```bash
+export CUBRID_HOST=localhost
+export CUBRID_PORT=33000        # optional, default: 33000
+export CUBRID_USER=readonly_user   # a CUBRID user with SELECT-only grants (see Security Model)
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+```
+
+Optional settings:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CUBRID_MCP_READONLY` | `1` | Enforce read-only SQL whitelist |
+| `CUBRID_MCP_MAX_CHARS` | `4000` | Max characters in query output |
+| `CUBRID_MCP_MAX_ROWS` | `1000` | Max rows returned by `execute_query` before truncation |
+| `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | Max length (characters) of a submitted SQL statement |
+| `CUBRID_MCP_QUERY_TIMEOUT` | `30` | Per-statement socket read timeout in seconds |
+| `CUBRID_MCP_AUDIT_LOG` | `0` | Opt-in audit logging (see Security Model) |
+| `CUBRID_MCP_WRITE` | `0` | Opt-in write mode (registers `execute_write`) |
+
+## 2. Run
+
+From PyPI with [`uvx`](https://docs.astral.sh/uv/guides/tools/):
+
+```bash
+uvx cubrid-mcp-server
+```
+
+Or with `pipx`:
+
+```bash
+pipx run cubrid-mcp-server
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cubrid-mcp-server
+```
+
+The server speaks MCP over stdio: it is not meant to be run standalone in a terminal, but registered as a server in an MCP client.
+
+## 3. Connect a client
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+## 4. First queries
+
+With the client connected, try:
+
+1. *"이 DB에 어떤 테이블이 있어?" / "What tables are in this database?"* — the client calls `all_table_names`.
+2. *"Show me the structure of the `orders` table"* — `describe_table` returns columns, primary key, and indexes.
+3. *"What are the top 5 products by revenue?"* — `execute_query` runs the `SELECT` and returns truncated, context-safe output.
+
+If you ask the model to delete a table, the read-only whitelist rejects it — that enforcement lives in the server, not in the prompt. See the [Security Model](SECURITY_MODEL.md) for the full design.
+
+## Next steps
+
+- [Tools reference](TOOLS.md) — every tool, resource, and prompt
+- [Multi-Connection](MULTI_CONNECTION.md) — serve several databases from one process
+- [Troubleshooting](TROUBLESHOOTING.md) — when something does not connect

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "yeongseon"
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: cubrid-mcp-server
+site_description: Model Context Protocol server for CUBRID database
+site_author: cubrid-lab
+site_url: https://cubrid-lab.github.io/cubrid-mcp-server/
+repo_url: https://github.com/cubrid-lab/cubrid-mcp-server
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Quick Start: quickstart.md
+  - Reference:
+      - Tools: TOOLS.md
+      - Security Model: SECURITY_MODEL.md
+      - Multi-Connection: MULTI_CONNECTION.md
+  - Operations:
+      - Troubleshooting: TROUBLESHOOTING.md
+  - 한국어: README.ko.md
+  - Changelog: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CHANGELOG.md
+  - Contributing: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CONTRIBUTING.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - tables
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+
+plugins:
+  - search
+
+validation:
+  nav:
+    omitted_files: ignore
+  links:
+    not_found: ignore
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/cubrid-lab/cubrid-mcp-server
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/cubrid-mcp-server/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ authors = [
 ]
 keywords = ["CUBRID", "database", "MCP", "Model Context Protocol", "LLM"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "Framework :: AsyncIO",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -50,6 +51,8 @@ cubrid-mcp-server = "cubrid_mcp_server.__main__:main"
 Homepage = "https://github.com/cubrid-lab/cubrid-mcp-server"
 Repository = "https://github.com/cubrid-lab/cubrid-mcp-server"
 Issues = "https://github.com/cubrid-lab/cubrid-mcp-server/issues"
+Documentation = "https://cubrid-lab.github.io/cubrid-mcp-server/"
+Changelog = "https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CHANGELOG.md"
 
 [tool.setuptools]
 packages = ["cubrid_mcp_server"]


### PR DESCRIPTION
## Summary

**The 0.4.0 release.** After this merges, a human pushes `v0.4.0` on the merged commit → `create-release.yml` → GitHub Release → `publish-pypi.yml` (trusted publishing, environment `pypi`). The PyPI **Pending Publisher must be registered first** (see checklist).

### Added
- **PyPI-first README**: `uvx cubrid-mcp-server` / `pipx run cubrid-mcp-server` lead the Run section; "not yet published" / "once published" notes removed. Official MCP Registry ownership marker (`mcp-name: io.github.cubrid-lab/cubrid-mcp-server`) embedded per registry package-verification spec; `glama.json` added for Glama indexing.
- **Docs site**: `mkdocs.yml` + `docs/` (index, quickstart, TOOLS, SECURITY_MODEL, MULTI_CONNECTION, TROUBLESHOOTING) + Korean README (`docs/README.ko.md` — siblings already ship ko/zh/hi/de/ru). Deployed by `.github/workflows/docs.yml` to `cubrid-lab.github.io/cubrid-mcp-server/` (same shape as pycubrid/sqlalchemy-cubrid). `mkdocs build --strict` clean.
- **fastmcp canary**: `upstream-canary.yml` gains a `fastmcp@latest` job. Rationale: fastmcp 4.0.0 (2026-08-31) is an SDK-v2 rewrite with breaking changes (ctx.sample/roots removal, httpx→httpx2, tasks→extension); the existing canary only tracks `pycubrid@main`. The pin intentionally stays `>=3.0,<4` (3.4.x is actively maintained and security-backported) until the canary informs a deliberate 4.x migration.

### Changed
- `Development Status :: 2 - Pre-Alpha` → `4 - Beta` — 0.3.x shipped multi-database connections, opt-in write mode, audit logging, Resources, and Prompts; Pre-Alpha undersells it.
- `[project.urls]` + `Documentation`/`Changelog`; `Framework :: AsyncIO` classifier.
- `cubrid_mcp_server/__version__` → `0.4.0`; CHANGELOG `[0.4.0] - 2026-09-09` (lint OK).

### Fixed
- README: duplicated `CUBRID_MCP_WRITE` row in the configuration table removed.

## Verification
- `make check` clean (ruff + mypy strict)
- 269 unit tests pass (`pytest -m "not integration"`)
- `python3 scripts/lint_changelog.py` OK
- `mkdocs build --strict` OK

## After merge (human gates)
- [ ] Register PyPI **Pending Publisher**: owner `cubrid-lab`, repo `cubrid-mcp-server`, workflow `publish-pypi.yml`, environment `pypi` (https://pypi.org/manage/account/pending-publishers/)
- [ ] `git tag v0.4.0 <merged-sha> && git push origin v0.4.0` → verify Release body → publish → PyPI
- [ ] Clean-machine check: `uvx cubrid-mcp-server`, Claude Desktop config, `all_table_names`
- [ ] `mcp-publisher publish` (Official MCP Registry) + Glama claim