### PR TITLE
ci: publish coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,22 @@ jobs:
         run: mypy cubrid_mcp_server
 
       - name: Pytest (unit)
-        run: pytest -m "not integration" --cov=cubrid_mcp_server --cov-report=term-missing
+        run: >-
+          pytest -m "not integration"
+          --cov=cubrid_mcp_server
+          --cov-report=term-missing
+          --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          verbose: true
+          fail_ci_if_error: false
+        env:
+          CODECOV_RETRIES: 3
 
   lowest-direct:
     # Verify the project works against the lowest versions of its direct

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ ENV/
 .pytest_cache/
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 .tox/
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cubrid-mcp-server
 
+[![coverage](https://codecov.io/gh/cubrid-lab/cubrid-mcp-server/branch/main/graph/badge.svg)](https://codecov.io/gh/cubrid-lab/cubrid-mcp-server)
+
 A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](https://www.cubrid.org/), enabling LLMs to safely inspect schemas and execute read-only queries via [pycubrid](https://pypi.org/project/pycubrid/).
 
 <!-- mcp-name: io.github.cubrid-lab/cubrid-mcp-server -->

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+
+parsers:
+  python:
+    build_root: .


### PR DESCRIPTION
Closes #146

## What

CI already collected coverage but discarded it — the report went to the job log and nothing else. This wires the existing coverage run up to Codecov.

- `ci.yml`: add `--cov-report=xml`, then upload via `codecov/codecov-action`
- `codecov.yml`: new, `target: auto` with a 2% threshold
- `README.md`: coverage badge
- `.gitignore`: `coverage.xml`, now produced on every run

## Notes on the upload step

```yaml
if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
```

The test matrix runs 3.10–3.13. Without a condition the same report uploads four times per run, so this mirrors what `cubrid-lab/pycubrid` already does: upload once from the lowest supported version, and skip dependabot runs.

The action is pinned to a commit SHA (`fb8b3582…`, v5), matching the pinning convention used elsewhere in this repo's workflows.

## Why `target: auto` instead of a fixed percentage

Coverage on `main` is currently **98.72%** (705 statements, 9 missed), well clear of the local `fail_under = 95`. A fixed Codecov target is still the wrong tool here — an absolute number drifts as the codebase grows and starts failing PRs for reasons unrelated to the change under review.

That failure mode has already cost this org time:

- #50 — the coverage gate never actually ran
- #87 — CI red on `main` after coverage fell below the gate
- `cubrid-lab/drizzle-cubrid#88` — a 95% threshold against 87% actual, still open

`target: auto` reports the delta a PR introduces instead of policing an absolute figure. `fail_under = 95` in `pyproject.toml` is untouched and remains the hard floor, so this does not loosen any existing gate.

## Verification

Ran locally against this branch (Python 3.12):

```
269 passed, 14 deselected in 4.31s
Coverage XML written to file coverage.xml
Required test coverage of 95.0% reached. Total coverage: 98.72%
```

`CODECOV_TOKEN` is present as an organization secret and resolves for this repository, so the upload step has what it needs on merge.
