### PR TITLE
ci: run integration tests against CUBRID 11.2 and 11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cubrid: ["11.2", "11.4"]
 
     steps:
       - uses: actions/checkout@v7
@@ -105,7 +109,7 @@ jobs:
             -e CUBRID_DB=demodb \
             -p 33000:33000 \
             -p 1523:1523 \
-            cubrid/cubrid:11.2
+            cubrid/cubrid:${{ matrix.cubrid }}
           docker ps
 
       - name: Wait for CUBRID demodb to be ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+- Integration tests now run against a CUBRID **11.2 + 11.4 job matrix** (previously 11.2 only), matching the pycubrid/sqlalchemy-cubrid integration matrices and the cookbook smoke matrix.
+
 ## [0.4.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `list_serials` now works on **CUBRID 11.4**: the `db_serial` system catalog renamed its `att_name` column to `attr_name` in 11.4, so the hardcoded query failed there with a semantic error. The column is now resolved once per connection by a zero-row probe against a fixed allowlist and aliased back to `att_name`, keeping the tool's output shape identical on both versions. Found by the new 11.2+11.4 integration matrix.
+
 ### CI
 - Integration tests now run against a CUBRID **11.2 + 11.4 job matrix** (previously 11.2 only), matching the pycubrid/sqlalchemy-cubrid integration matrices and the cookbook smoke matrix.
 

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -101,9 +101,7 @@ class Database:
                     self._serial_attribute_column = column
                     break
                 else:
-                    raise DatabaseError(
-                        "db_serial exposes neither att_name nor attr_name"
-                    )
+                    raise DatabaseError("db_serial exposes neither att_name nor attr_name")
             return self._serial_attribute_column
 
     def connect(self) -> Any:

--- a/cubrid_mcp_server/database.py
+++ b/cubrid_mcp_server/database.py
@@ -76,10 +76,35 @@ class Database:
     serialization is ever shown, by measurement, to be a real bottleneck.
     """
 
+    _SERIAL_ATTRIBUTE_COLUMNS = ("att_name", "attr_name")
+
     def __init__(self, config: Config) -> None:
         self._config = config
         self._connection: Any = None
         self._lock = threading.RLock()
+        self._serial_attribute_column: str | None = None
+
+    def serial_attribute_column(self) -> str:
+        """Resolve ``db_serial``'s attribute column once per connection.
+
+        CUBRID 11.2 names it ``att_name``; 11.4 renamed it to ``attr_name``.
+        Probed with a zero-row SELECT and cached, so every later
+        ``list_serials`` call uses the version-correct identifier.
+        """
+        with self._lock:
+            if self._serial_attribute_column is None:
+                for column in self._SERIAL_ATTRIBUTE_COLUMNS:
+                    try:
+                        self.fetch_all(f'SELECT "{column}" FROM db_serial WHERE 1 = 0')
+                    except DatabaseError:
+                        continue
+                    self._serial_attribute_column = column
+                    break
+                else:
+                    raise DatabaseError(
+                        "db_serial exposes neither att_name nor attr_name"
+                    )
+            return self._serial_attribute_column
 
     def connect(self) -> Any:
         # Return the cached connection without a liveness ping: pinging on every

--- a/cubrid_mcp_server/server.py
+++ b/cubrid_mcp_server/server.py
@@ -274,10 +274,15 @@ def _quote_ident(name: str) -> str:
 @mcp.tool
 def list_serials(connection: str | None = None) -> list[dict[str, Any]]:
     """Return CUBRID SERIAL sequences with current value, increment, and bounds."""
-    rows = _db(connection).fetch_all(
-        """
+    database = _db(connection)
+    # Identifier comes from Database's fixed allowlist (att_name/attr_name),
+    # never from user input, so interpolation here is injection-safe.
+    att_column = database.serial_attribute_column()
+    rows = database.fetch_all(
+        f"""
         SELECT name, current_val, increment_val, max_val, min_val,
-               cyclic, started, class_name, att_name, cached_num, comment
+               cyclic, started, class_name, {att_column} AS att_name,
+               cached_num, comment
         FROM db_serial
         ORDER BY name
         """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,6 +35,9 @@ class FakeDatabase:
     def queue(self, rows: list[tuple[Any, ...]]) -> None:
         self.responses.append(rows)
 
+    def serial_attribute_column(self) -> str:
+        return "att_name"
+
     def fetch_all(self, sql: str, params: tuple[Any, ...] | None = None) -> list[tuple[Any, ...]]:
         self.calls.append((sql, params or ()))
         if not self.responses:


### PR DESCRIPTION
## Summary
- `ci.yml`'s `integration` job ran a single `cubrid/cubrid:11.2` container; it now runs a **11.2 + 11.4 job matrix** (`fail-fast: false`), matching pycubrid/sqlalchemy-cubrid integration matrices and the cookbook smoke matrix (which went 11.4-green today in cubrid-cookbook-python#96).
- Rationale: evaluators are likely to try CUBRID 11.4; until now the server's live-DB tests only proved 11.2.
- Job id unchanged (`integration`), so the `ci-gate` aggregation job needs no change. CHANGELOG `[Unreleased]` entry added (docs-sync).

## Test plan
- [ ] CI: both matrix legs green on this PR