### PR TITLE
ci+docs: SBOM on releases; server-license statement; dual authors

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -91,3 +91,17 @@ jobs:
               --verify-tag \
               --target "$TAG"
           fi
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" sbom.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 - Integration tests now run against a CUBRID **11.2 + 11.4 job matrix** (previously 11.2 only), matching the pycubrid/sqlalchemy-cubrid integration matrices and the cookbook smoke matrix.
 
+### Documentation
+- **CUBRID server license relationship documented; copyright and authors unified (#150)** — `THIRD_PARTY_LICENSES.md` carries the verified upstream licensing statement (server engine Apache-2.0, APIs/connectors BSD per CUBRID's `COPYING` — the often-cited GPL v2+ no longer applies; independent wire-protocol client, Docker image CI-only). LICENSE/NOTICE copyright lines now read `Yeongseon Choe and Gyeongjun Paik` (2025-2026), and `pyproject.toml` lists both primary authors.
+
 ## [0.4.0] - 2026-09-09
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Yeongseon Choe
+Copyright (c) 2025-2026 Yeongseon Choe and Gyeongjun Paik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 cubrid-mcp-server
-Copyright (c) 2025 Yeongseon Choe
+Copyright (c) 2025-2026 Yeongseon Choe and Gyeongjun Paik
 
 This product is licensed under the MIT License (see LICENSE).
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -4,6 +4,13 @@ This file lists the third-party open-source software used by **cubrid-mcp-server
 
 All listed dependencies are distributed under permissive licenses (MIT, BSD-2/3-Clause, Apache-2.0, ISC, PSF, MPL-2.0, Unlicense). No dependency is copyleft/GPL, and none conflicts with this project's MIT license. The single MPL-2.0 package (`certifi`) is a file-level-licensed data bundle distributed unmodified.
 
+> **CUBRID server license, for the record.** The CUBRID server engine is
+> distributed under Apache License 2.0 and the official APIs/connectors under
+> BSD (upstream `COPYING`, http://www.cubrid.org/cubrid) — the frequently cited
+> GPL v2+ no longer applies. This project is an independent wire-protocol client
+> that neither includes nor links any CUBRID server code; the `cubrid/cubrid`
+> Docker image is used for CI verification only.
+
 Direct runtime dependencies: `fastmcp>=3.0,<4` (Apache-2.0), `pycubrid>=1.4,<2` (MIT), `sqlparse>=0.5,<1` (BSD). Everything else below is pulled in transitively by `fastmcp`.
 
 ## Runtime dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
+    {name = "Yeongseon Choe", email = "yeongseon.choe@gmail.com"},
     {name = "Gyeongjun Paik", email = "paikend@gmail.com"},
 ]
 keywords = ["CUBRID", "database", "MCP", "Model Context Protocol", "LLM"]


### PR DESCRIPTION
Fixes #149, fixes #150

- ci: create-release.yml gains the same Generate SBOM + gh release upload steps pycubrid (#307) and sqlalchemy-cubrid (#331) use — must land before the v0.4.0 tag so the first PyPI release carries an SBOM asset.
- docs: THIRD_PARTY_LICENSES.md server-license statement (engine Apache-2.0, APIs/connectors BSD — verified upstream COPYING; GPL v2+ outdated; independent wire-protocol client). LICENSE/NOTICE to 'Yeongseon Choe and Gyeongjun Paik'; pyproject authors now list both.

make check clean, 269 unit tests pass.