### PR TITLE
ci: drop --target from gh release create (422 on existing tags)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,8 +88,7 @@ jobs:
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file RELEASE_NOTES.md \
-              --verify-tag \
-              --target "$TAG"
+              --verify-tag
           fi
 
       - name: Generate SBOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **create-release.yml: dropped `--target` from `gh release create`** — with an already-pushed tag (the normal tag-push trigger) `--verify-tag` already guarantees the tag exists, and passing `target_commitish` for an existing tag makes the Releases API return `422 Validation Failed`, so the first tag-triggered run of this workflow always failed. Verified live by the v0.4.0 tag attempt in cubrid-mcp-server.
+
+### Fixed
 - `list_serials` now works on **CUBRID 11.4**: the `db_serial` system catalog renamed its `att_name` column to `attr_name` in 11.4, so the hardcoded query failed there with a semantic error. The column is now resolved once per connection by a zero-row probe against a fixed allowlist and aliased back to `att_name`, keeping the tool's output shape identical on both versions. Found by the new 11.2+11.4 integration matrix.
 
 ### CI


### PR DESCRIPTION
First live run of the tag-push trigger (v0.4.0) failed with HTTP 422: `--target`/`target_commitish` is rejected for an already-existing tag ref, and `--verify-tag` already guarantees existence. Same fix pending in pycubrid and sqlalchemy-cubrid (canonical workflow bug, never exposed because those repos have not released through this workflow yet). Blocking the v0.4.0 PyPI release — merging immediately.