### PR TITLE
docs(site): unified six-tab IA, translations group, ecosystem links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Documentation
+- **Docs site information architecture unified across the ecosystem** — nav reorganized to the shared six-tab skeleton (Home / Getting Started / Usage / Reference / Operations / Project): Tools and Multi-Connection under Usage, Security Model under Reference, 한국어 under Project → Translations; homepage gains an Ecosystem section linking the three sibling sites.
 - **Community files**: bug/feature issue templates (adapted from the siblings, with an MCP-specific environment field: server/Python/CUBRID/client versions), `SUPPORT.md`, and `CODE_OF_CONDUCT.md` — the repo previously relied on org-level fallbacks only. README gains the docs-site badge matching pycubrid and sqlalchemy-cubrid.
 - README gains a **Related Projects** section linking pycubrid, sqlalchemy-cubrid, and cubrid-cookbook-python, matching the sibling packages' READMEs — every cubrid-lab PyPI page now leads to the runnable examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,3 +46,12 @@ See the full [Tools reference](TOOLS.md) for parameters and return shapes, the [
 MIT — see [LICENSE](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/LICENSE).
 
 > This project is part of [CUBRID Lab](https://github.com/cubrid-lab), an independent open-source initiative for CUBRID developer tooling, and is not affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.
+
+## Ecosystem
+
+Part of the cubrid-lab Python ecosystem:
+
+- **cubrid-mcp-server** — MCP server — natural-language access for LLM clients
+- [pycubrid](https://github.com/cubrid-lab/pycubrid) — Pure-Python DB-API 2.0 driver for CUBRID (sync + native asyncio)
+- [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — SQLAlchemy 2.0–2.2 dialect + Alembic
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — 68 runnable examples and application templates

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,13 +31,16 @@ nav:
   - Home: index.md
   - Getting Started:
       - Quick Start: quickstart.md
-  - Reference:
+  - Usage:
       - Tools: TOOLS.md
-      - Security Model: SECURITY_MODEL.md
       - Multi-Connection: MULTI_CONNECTION.md
+  - Reference:
+      - Security Model: SECURITY_MODEL.md
   - Operations:
       - Troubleshooting: TROUBLESHOOTING.md
-  - 한국어: README.ko.md
+  - Project:
+      - Translations:
+          - 한국어: README.ko.md
   - Changelog: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CHANGELOG.md
   - Contributing: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CONTRIBUTING.md
 


### PR DESCRIPTION
Nav aligned to the shared skeleton: Tools + Multi-Connection under Usage, Security Model under Reference, 한국어 under Project → Translations; homepage Ecosystem section. Strict build green.