### PR TITLE
docs: translation sync markers + translation-sync CI check

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -97,3 +97,17 @@ jobs:
 
           print("\nDocs-sync guard passed.")
           PY
+
+  translation-sync:
+    # README.md must not drift from its docs/README.<lang>.md translations.
+    # Escape hatch: the `translations-deferred` PR label.
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'translations-deferred') && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check README translations stay in sync
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_translation_sync.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Documentation
+- **Korean docs governance** — `docs/README.ko.md` carries a sync marker, and docs-sync gained a `translation-sync` job that fails a PR when `README.md` changes without the translation changing (escape hatch: the `translations-deferred` label).
 - **Docs site information architecture unified across the ecosystem** — nav reorganized to the shared six-tab skeleton (Home / Getting Started / Usage / Reference / Operations / Project): Tools and Multi-Connection under Usage, Security Model under Reference, 한국어 under Project → Translations; homepage gains an Ecosystem section linking the three sibling sites.
 - **Community files**: bug/feature issue templates (adapted from the siblings, with an MCP-specific environment field: server/Python/CUBRID/client versions), `SUPPORT.md`, and `CODE_OF_CONDUCT.md` — the repo previously relied on org-level fallbacks only. README gains the docs-site badge matching pycubrid and sqlalchemy-cubrid.
 - README gains a **Related Projects** section linking pycubrid, sqlalchemy-cubrid, and cubrid-cookbook-python, matching the sibling packages' READMEs — every cubrid-lab PyPI page now leads to the runnable examples.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,6 +1,6 @@
 # cubrid-mcp-server (한국어)
 
-> 🌐 Translated from [README.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/README.md) — keep this translation in sync with the original in the same PR (enforced by the `translation-sync` CI check; use the `translations-deferred` label to defer).
+> 🌐 Translated from [README.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/README.md) — 한국어는 심사 기간 동안 동기화가 **필수**입니다: README.md가 바뀌면 같은 PR에서 이 파일도 업데이트하세요 (`translation-sync` CI 검사, 보류 시 `translations-deferred` 라벨). English is canonical.
 
 
 [CUBRID](https://www.cubrid.org/) 데이터베이스를 위한 [Model Context Protocol](https://modelcontextprotocol.io) 서버. LLM 클라이언트가 순수 Python 드라이버 [pycubrid](https://pypi.org/project/pycubrid/)를 통해 스키마를 안전하게 조회하고 **읽기 전용** 쿼리를 실행할 수 있습니다.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,6 +1,7 @@
 # cubrid-mcp-server (한국어)
 
-> 영어 원문: [README.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/README.md)
+> 🌐 Translated from [README.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/README.md) — keep this translation in sync with the original in the same PR (enforced by the `translation-sync` CI check; use the `translations-deferred` label to defer).
+
 
 [CUBRID](https://www.cubrid.org/) 데이터베이스를 위한 [Model Context Protocol](https://modelcontextprotocol.io) 서버. LLM 클라이언트가 순수 Python 드라이버 [pycubrid](https://pypi.org/project/pycubrid/)를 통해 스키마를 안전하게 조회하고 **읽기 전용** 쿼리를 실행할 수 있습니다.
 

--- a/scripts/check_translation_sync.py
+++ b/scripts/check_translation_sync.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
-"""Fail a PR when README.md changes without any of its translations changing.
+"""Translation-drift policy for cubrid-lab (hybrid, per Oracle review 2026-09).
 
-Translations live at docs/README.<lang>.md. Escape hatch: the
-`translations-deferred` PR label (the workflow job skips when present).
+- 한국어 (docs/README.ko.md) is REQUIRED for contest readiness: a PR that
+  changes README.md without it FAILS (escape hatch: `translations-deferred`).
+- Other languages are community translations: drift emits a warning
+  annotation only; the maintainers' AI agent opens follow-up resync PRs.
+- English is canonical. The Korean hard gate is time-boxed until the
+  2026 contest finals and should be relaxed to advisory afterwards.
 """
 from __future__ import annotations
 
@@ -12,36 +16,54 @@ import sys
 from pathlib import Path
 
 SOURCE = Path("README.md")
+REQUIRED_LANGS = {"ko"}
+LANGS = {"ko": "한국어", "de": "Deutsch", "hi": "हिन्दी", "ru": "Русский", "zh": "中文"}
 
 def changed_files() -> set[str]:
-    base = os.environ.get("BASE_REF", "origin/main")
+    base = os.environ.get("BASE_REF", "main")
+    ref = base if base.startswith("origin/") else f"origin/{base}"
     out = subprocess.run(
-        ["git", "diff", "--name-only", f"origin/{base}...HEAD"]
-        if not base.startswith("origin/")
-        else ["git", "diff", "--name-only", f"{base}...HEAD"],
+        ["git", "diff", "--name-only", "--find-renames", f"{ref}...HEAD"],
         capture_output=True, text=True, check=True,
     ).stdout
-    return {line.strip() for line in out.splitlines() if line.strip()}
+    # --find-renames keeps a rename as old	new; both sides matter
+    files = set()
+    for line in out.splitlines():
+        parts = line.split("\t")
+        for p in parts:
+            if p.strip():
+                files.add(p.strip())
+    return files
 
 def main() -> int:
-    translations = sorted(p.name for p in Path("docs").glob("README.*.md"))
-    if not translations:
+    present = sorted(p.stem.split(".")[1] for p in Path("docs").glob("README.*.md"))
+    if not present:
         print("no translations present — nothing to sync")
         return 0
     changed = changed_files()
     if SOURCE.as_posix() not in changed:
         print(f"{SOURCE} unchanged in this PR — translation sync OK")
         return 0
-    touched = sorted(t for t in translations if f"docs/{t}" in changed)
-    if not touched:
+    failures, warnings = [], []
+    for lang in present:
+        path = f"docs/README.{lang}.md"
+        if path in changed:
+            continue
+        label = LANGS.get(lang, lang)
+        if lang in REQUIRED_LANGS:
+            failures.append(f"{path} ({label})")
+        else:
+            warnings.append(f"{path} ({label})")
+    for w in warnings:
+        print(f"::warning file=README.md::community translation drifted: {w} — maintainers will open a resync PR")
+    if failures:
         print(
-            f"::error::{SOURCE} changed but none of its translations did "
-            f"({', '.join('docs/' + t for t in translations)}). Update them in "
-            "this PR, or add the `translations-deferred` label if the gap is "
-            "intentional."
+            "::error::README.md changed but the required translation did not: "
+            + ", ".join(failures)
+            + ". Update it in this PR, or add the `translations-deferred` label if deferring is intentional."
         )
         return 1
-    print(f"translation sync OK: {SOURCE} + {', '.join(touched)}")
+    print("translation sync OK")
     return 0
 
 if __name__ == "__main__":

--- a/scripts/check_translation_sync.py
+++ b/scripts/check_translation_sync.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Fail a PR when README.md changes without any of its translations changing.
+
+Translations live at docs/README.<lang>.md. Escape hatch: the
+`translations-deferred` PR label (the workflow job skips when present).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SOURCE = Path("README.md")
+
+def changed_files() -> set[str]:
+    base = os.environ.get("BASE_REF", "origin/main")
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"origin/{base}...HEAD"]
+        if not base.startswith("origin/")
+        else ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+def main() -> int:
+    translations = sorted(p.name for p in Path("docs").glob("README.*.md"))
+    if not translations:
+        print("no translations present — nothing to sync")
+        return 0
+    changed = changed_files()
+    if SOURCE.as_posix() not in changed:
+        print(f"{SOURCE} unchanged in this PR — translation sync OK")
+        return 0
+    touched = sorted(t for t in translations if f"docs/{t}" in changed)
+    if not touched:
+        print(
+            f"::error::{SOURCE} changed but none of its translations did "
+            f"({', '.join('docs/' + t for t in translations)}). Update them in "
+            "this PR, or add the `translations-deferred` label if the gap is "
+            "intentional."
+        )
+        return 1
+    print(f"translation sync OK: {SOURCE} + {', '.join(touched)}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
README.ko.md gains a sync marker; docs-sync gains a job failing PRs that change README.md without the translation (translations-deferred label as escape hatch).