### PR TITLE
docs: Korean site pages — docs/ko/ (5 pages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Documentation
+- **한국어 문서 페이지 (#160)** — 사이트 문서 5개 페이지(quickstart·TOOLS·보안 모델·멀티커넥션·문제 해결)의 한국어 번역을 `docs/ko/`에 추가하고 Project → Translations → 한국어 문서로 노출. 페이지 번역은 경고 수준 동기화(README.ko의 하드 게이트는 유지).
 - **Korean docs governance** — `docs/README.ko.md` carries a sync marker, and docs-sync gained a `translation-sync` job that fails a PR when `README.md` changes without the translation changing (escape hatch: the `translations-deferred` label).
 - **Docs site information architecture unified across the ecosystem** — nav reorganized to the shared six-tab skeleton (Home / Getting Started / Usage / Reference / Operations / Project): Tools and Multi-Connection under Usage, Security Model under Reference, 한국어 under Project → Translations; homepage gains an Ecosystem section linking the three sibling sites.
 - **Community files**: bug/feature issue templates (adapted from the siblings, with an MCP-specific environment field: server/Python/CUBRID/client versions), `SUPPORT.md`, and `CODE_OF_CONDUCT.md` — the repo previously relied on org-level fallbacks only. README gains the docs-site badge matching pycubrid and sqlalchemy-cubrid.

--- a/docs/ko/MULTI_CONNECTION.md
+++ b/docs/ko/MULTI_CONNECTION.md
@@ -1,0 +1,67 @@
+# 멀티커넥션 (한국어)
+
+> 🌐 [MULTI_CONNECTION.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/docs/MULTI_CONNECTION.md)의 번역입니다. 영어 원문이 표준이며, 페이지 번역은 경고 수준의 동기화 규칙을 따릅니다.
+
+하나의 서버 프로세스로 여러 CUBRID 데이터베이스를 서빙할 수 있습니다. 모든 도구는 대상을 선택하는 선택적 `connection` 인자를 받으며, 단일 데이터베이스 구성은 그대로 작동합니다.
+
+## 기본 연결
+
+`CUBRID_*` 변수만으로 `default`라는 이름의 단일 연결이 구성됩니다:
+
+```bash
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+```
+
+## 이름 있는 연결
+
+`CUBRID_CONNECTIONS`(쉼표 구분)에 추가 연결 이름을 나열하고, 각각에 `CUBRID_<NAME>_*` 변수를 제공합니다:
+
+```bash
+# 기본 연결 (기존과 동일)
+export CUBRID_HOST=localhost
+export CUBRID_USER=readonly_user
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+
+# 추가 이름 있는 연결들
+export CUBRID_CONNECTIONS=reporting,analytics
+
+export CUBRID_REPORTING_HOST=reporting-db
+export CUBRID_REPORTING_USER=readonly_user
+export CUBRID_REPORTING_PASSWORD=secret
+export CUBRID_REPORTING_DATABASE=reports
+export CUBRID_REPORTING_MCP_MAX_ROWS=500   # 연결별 선택 튜닝
+
+export CUBRID_ANALYTICS_HOST=analytics-db
+export CUBRID_ANALYTICS_USER=readonly_user
+export CUBRID_ANALYTICS_PASSWORD=secret
+export CUBRID_ANALYTICS_DATABASE=analytics
+```
+
+이제 클라이언트 대화에서 *"analytics 데이터베이스에서 … 조회해줘"*라고 하면 모델이 도구에 `connection="analytics"`를 전달합니다.
+
+## 규칙
+
+- 연결 이름은 `[A-Za-z0-9_]+` 형식이며 대소문자를 구분하지 않습니다.
+- `default`는 예약된 이름입니다(항상 `CUBRID_*` 기본 변수에서 옴) — `CUBRID_CONNECTIONS`에 넣을 수 없습니다.
+- 이름 있는 연결 `<NAME>`의 연결 필드는 `CUBRID_<NAME>_HOST` 등에, 선택 튜닝은 `CUBRID_<NAME>_MCP_*`(전역 것과 같은 접미사)에 둡니다.
+- 이름 있는 연결은 기본 변수를 **상속하지 않습니다** — 모든 필드를 각각 지정해야 합니다.
+- 알 수 없는 연결을 선택하면 사용 가능한 이름을 안내하는 명확한 오류가 반환됩니다.
+
+## 연결별 격리
+
+각 연결은 독립적으로 구성되고 강제됩니다:
+
+| 설정 | 연결별 변수 | 효과 |
+|---------|------------------------|------|
+| 읽기 전용 | `CUBRID_<NAME>_MCP_READONLY` | 이 연결에만 화이트리스트 강제 |
+| 쓰기 모드 | `CUBRID_<NAME>_MCP_WRITE` | 이 연결에만 `execute_write` 옵트인 |
+| 감사 로그 | `CUBRID_<NAME>_MCP_AUDIT_LOG` | 이 연결에만 감사 스트림 |
+| 출력 제한 | `CUBRID_<NAME>_MCP_MAX_ROWS` / `_MAX_CHARS` / `_MAX_SQL_LENGTH` / `_QUERY_TIMEOUT` | 이 연결에만 튜닝 |
+
+각 연결은 자체 잠금·연결 수명 주기·끊어진 연결 복구를 가지므로, 한 데이터베이스에서 쿼리가 멈춰도 다른 연결을 막지 않습니다.
+
+쓰기 모드 등록의 미묘한 점: 어떤 연결이든 쓰기를 켜면 `execute_write`가 MCP 기능 탐색에 등장하지만, 매 호출은 **대상** 연결의 설정으로 강제됩니다 — 쓰기가 꺼진 연결은 다른 연결이 켜져 있어도 쓰기를 거부합니다. [보안 모델](SECURITY_MODEL.ko.md#계층-2b--옵트인-쓰기-모드-cubrid_mcp_write) 참고.

--- a/docs/ko/SECURITY_MODEL.md
+++ b/docs/ko/SECURITY_MODEL.md
@@ -1,0 +1,68 @@
+# 보안 모델 (한국어)
+
+> 🌐 [SECURITY_MODEL.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/docs/SECURITY_MODEL.md)의 번역입니다. 영어 원문이 표준이며, 페이지 번역은 경고 수준의 동기화 규칙을 따릅니다.
+
+`cubrid-mcp-server`는 CUBRID 데이터베이스와 MCP를 사용하는 LLM 클라이언트를 잇는 다리입니다. 모델이 보내는 모든 쿼리를 신뢰할 수 없는 입력으로 취급하세요: LLM은 파괴적 SQL을 환각할 수 있고, 악의적인 프롬프트는 서버가 노출할 의도가 없던 데이터를 빼내려 할 수 있습니다. **심층 방어**가 설계 의도입니다.
+
+## 계층 1 — 데이터베이스 권한 (필수)
+
+모델이 사용하길 원하는 권한**만** 가진 전용 CUBRID 사용자로 서버를 실행하세요. 코드 수준의 안전 검사기는 이것을 대신할 수 없습니다.
+
+```sql
+-- 1. 사용자 생성
+CREATE USER mcp_reader PASSWORD 'replace-me';
+
+-- 2. 노출할 테이블에만 SELECT 권한 부여.
+--    CUBRID는 테이블 단위 권한 부여입니다 (스키마 전체 db.* 부여는 없음).
+GRANT SELECT ON customers TO mcp_reader;
+GRANT SELECT ON orders TO mcp_reader;
+-- ...모델이 읽을 수 있는 각 테이블마다 반복.
+
+-- 3. CREATE, ALTER, DROP, INSERT, UPDATE, DELETE, GRANT, DBA 역할은 부여 금지.
+```
+
+추가 강화: 시크릿 매니저의 긴 무작위 비밀번호 사용, 정기적 로테이션, 스키마 전체가 아닌 테이블 단위 부여, MCP 서버 호스트만 접근 가능한 네트워크에 CUBRID 두기. 전체 정책은 [`SECURITY.md`](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/SECURITY.md)를 참고하세요.
+
+## 계층 2 — 읽기 전용 SQL 화이트리스트
+
+서버는 **기본적으로 읽기 전용**입니다. `CUBRID_MCP_READONLY=1`(기본값)이면 모든 문장이 `sqlparse`로 파싱되어 `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH`(CTE)가 아니면 거부됩니다. 다중 문장 입력은 즉시 거부되므로 `; DROP TABLE …`이 뒤에 붙는 것도 막힙니다.
+
+> 이 화이트리스트는 심층 방어이지 보안 경계가 아닙니다. 명백한 실수를 막는 파서 기반 가드레일일 뿐이며, 실제 강제 계층은 데이터베이스 자신입니다(계층 1).
+
+`CUBRID_MCP_READONLY=0`은 이 계층을 끕니다 — 데이터베이스 사용자가 이미 읽기 전용이고 파서가 오판하는 문장이 필요할 때만 사용하세요. `explain_query`는 이 플래그와 무관하게 **항상** 읽기 전용입니다. `execute_query`만 이 설정을 따릅니다.
+
+## 계층 2b — 옵트인 쓰기 모드 (`CUBRID_MCP_WRITE`)
+
+쓰기 접근은 **기본적으로 꺼져 있습니다**. `CUBRID_MCP_WRITE=1`을 설정하면 별도의 `execute_write` 도구가 등록되며 다음으로 제한됩니다:
+
+- **DML 전용.** 전용 화이트리스트(`ensure_write_allowed`)가 **단일** `INSERT`/`UPDATE`/`DELETE`만 허용하고, 독립 실행형 읽기·DDL·트랜잭션 제어·다중 문장 입력을 거부합니다. (단일 DML 안의 서브쿼리, 예컨대 `INSERT ... SELECT`는 합법적으로 허용됩니다.)
+- **원자적 트랜잭션.** 문장은 명시적 트랜잭션에서 실행됩니다 — 성공 시 커밋, 어떤 실패든 롤백.
+- **DDL은 의도적으로 미지원.** CUBRID는 DDL을 자동 커밋해서 롤백 보장이 무의미해지므로, `CREATE`/`ALTER`/`DROP`/`TRUNCATE`는 절대 허용되지 않습니다.
+- **비활성 시 미등록.** 쓰기 모드가 꺼져 있으면 `execute_write`는 MCP 기능 탐색에 나타나지 않습니다 — 지켜지는 경로가 아니라 아예 닿을 수 없는 경로입니다.
+- **연결별 게이팅.** 멀티커넥션에서 어떤 연결이 쓰기를 켜면 도구가 등록되지만, 매 쓰기는 **대상** 연결의 설정으로 강제됩니다 — 쓰기가 꺼진 연결은 다른 연결이 켜져 있어도 거부합니다.
+- `execute_query`는 쓰기 플래그와 무관하게 **항상 읽기 전용**입니다.
+
+## 계층 3 — 출력 제한
+
+`execute_query`는 행을 `CUBRID_MCP_MAX_ROWS`(기본 1000)로, 렌더링된 출력을 `CUBRID_MCP_MAX_CHARS`(기본 4000)로 제한합니다. 이는 모델의 컨텍스트 창을 보호하고 한 번의 탐색 쿼리가 빼낼 수 있는 데이터량을 제한합니다. 바이너리 값은 작으면 base64로, 크면 요약됩니다(`<binary N bytes>`).
+
+## 계층 4 — 감사 로그 (옵트인)
+
+`CUBRID_MCP_AUDIT_LOG=1`을 설정하면 실행된 문장(`execute_query`, `explain_query`, `execute_write`)마다 **stderr**에 구조화된 JSON 기록 한 줄이 남습니다. 기본은 꺼짐이며 연결별로 적용됩니다(`CUBRID_<NAME>_MCP_AUDIT_LOG`).
+
+| 필드 | 설명 |
+|-------|------|
+| `tool` | 문장을 실행한 MCP 도구 |
+| `status` | `ok` 또는 `error` |
+| `category` | 선행 SQL 키워드만 (예: `SELECT`, `WITH`) — 전체 문장은 절대 기록 안 함 |
+| `identifiers` | `FROM`/`JOIN` 뒤에서 식별자 정규식으로 추출한 테이블 이름. 식별자가 아닌 것(값, 리터럴, 표현식)은 버려짐 |
+| `sql_length` | 제출된 SQL의 글자 수 |
+| `row_count`, `truncated` | 결과 크기 및 잘림 여부 (성공 시만) |
+| `duration_ms` | 호출 소요 시간 (정수 밀리초) |
+| `error_type` | 실패 시 예외 클래스 이름만 |
+
+**원본 SQL 텍스트, 바인드 파라미터, 리터럴 값은 절대 기록되지 않습니다** — 쿼리에 박힌 비밀이 감사 스트림으로 새지 않습니다.
+
+## 로깅 규율
+
+서버는 MCP stdio를 사용합니다: `stdout`은 JSON-RPC 프로토콜 스트림으로 예약되어 있어 **모든 로그는 `stderr`로** 출력됩니다(기본 레벨 `INFO`). LLM 클라이언트에 반환되는 오류는 **재던션 처리**됩니다 — 예외 카테고리(예: `query failed: OperationalError`)만 반환되고 전체 세부 정보는 운영자를 위해 stderr에 기록됩니다. 스키마 세부 사항, 호스트명, SQL 조각, 설정 값이 클라이언트에 노출되지 않습니다.

--- a/docs/ko/TOOLS.md
+++ b/docs/ko/TOOLS.md
@@ -1,0 +1,94 @@
+# 도구 참조 (한국어)
+
+> 🌐 [TOOLS.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/docs/TOOLS.md)의 번역입니다. 영어 원문이 표준이며, 페이지 번역은 경고 수준의 동기화 규칙을 따릅니다.
+
+`cubrid-mcp-server`는 MCP **도구**·**리소스**·**프롬프트**로 기능을 노출합니다. 모든 도구는 선택적 `connection` 인자를 받으며( [멀티커넥션](MULTI_CONNECTION.ko.md) 참고), 생략하면 `default` 연결을 대상으로 합니다.
+
+## 도구
+
+### 스키마 조회
+
+#### `all_table_names(connection=None)`
+
+데이터베이스의 모든 사용자 테이블을 나열합니다. 시스템·카탈로그 테이블은 제외됩니다.
+
+#### `filter_table_names(substring, connection=None)`
+
+테이블 이름에 대한 대소문자 구분 없는 부분 문자열 검색. 스키마가 클 때 `all_table_names` 대신 사용하세요.
+
+#### `schema_definitions(table_name, connection=None)`
+
+한 테이블의 컬럼 수준 메타데이터: 컬럼 이름·타입·NULL 허용 여부·기본값·기본 키 포함 여부.
+
+#### `describe_table(table_name, connection=None)`
+
+한 테이블의 전체 메타데이터를 한 번의 호출로 — 컬럼, 기본 키, 인덱스. `cubrid://schema/{table}` 리소스와 동일합니다.
+
+#### `list_indexes(table_name, connection=None)`
+
+테이블에 정의된 인덱스와 인덱스된 키 컬럼·플래그(유니크, 리버스).
+
+#### `list_class_hierarchy(connection=None, ...)`
+
+CUBRID `CLASS` 상속 관계 — 어느 테이블이 어느 테이블을 상속하는지.
+
+### 쿼리
+
+#### `execute_query(sql, connection=None)`
+
+**읽기 전용** SQL(`SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH`)을 실행합니다. 출력은 모델의 컨텍스트 창을 보호하도록 자동 잘림됩니다:
+
+- 최대 `CUBRID_MCP_MAX_ROWS`행 (기본 1000)
+- 렌더링된 출력은 `CUBRID_MCP_MAX_CHARS`자로 제한 (기본 4000)
+- 문장 길이는 `CUBRID_MCP_MAX_SQL_LENGTH`로 제한 (기본 65536)
+- 문장별 소켓 읽기 타임아웃 `CUBRID_MCP_QUERY_TIMEOUT`초 (기본 30)
+
+다중 문장 입력은 거부됩니다. 바이너리 값은 작으면 base64로 인코딩되고 크면 요약됩니다(`<binary N bytes>`).
+
+#### `explain_query(sql, connection=None)`
+
+CUBRID `SHOW TRACE`를 통해 `SELECT`/`WITH` 문의 실행 계획/트레이스를 반환합니다. `CUBRID_MCP_READONLY` 플래그와 무관하게 항상 읽기 전용입니다.
+
+#### `table_row_counts(connection=None, ...)`
+
+한 테이블 또는 여러 테이블의 `COUNT(*)` — 크기를 추정하려고 행을 샘플링하는 것보다 저렴합니다.
+
+### CUBRID 특화
+
+#### `list_serials(connection=None)`
+
+CUBRID `SERIAL` 시퀀스와 현재값·최솟값·최댓값·증분. (`db_serial` 카탈로그의 컬럼명은 CUBRID 11.4에서 `att_name`→`attr_name`으로 개명되어, 서버 버전에 따라 자동으로 해석합니다.)
+
+#### `health_check(connection=None)`
+
+데이터베이스 연결 상태를 요청 시점에 확인하고 연결별 상태를 보고합니다. 환경 변경 후나 긴 유휴 후에 유용합니다.
+
+### 옵트인 쓰기
+
+#### `execute_write(sql, connection=None)`
+
+**단일** `INSERT`/`UPDATE`/`DELETE` 문을 명시적 트랜잭션(성공 시 커밋, 실패 시 롤백)으로 실행합니다. **쓰기 모드가 활성화된 경우에만 등록**됩니다(`CUBRID_MCP_WRITE=1` 또는 특정 연결의 `CUBRID_<NAME>_MCP_WRITE=1`) — 쓰기 모드가 꺼져 있으면 MCP 기능 탐색에 이 도구가 아예 존재하지 않습니다.
+
+제약: DDL(`CREATE`/`ALTER`/`DROP`/`TRUNCATE`), 독립 실행형 읽기, 트랜잭션 제어, 다중 문장 입력은 거부됩니다. [보안 모델](SECURITY_MODEL.ko.md) 참고.
+
+## 리소스
+
+스키마 메타데이터는 읽기 전용 [MCP 리소스](https://modelcontextprotocol.io/docs/concepts/resources)로도 노출되어, 클라이언트가 도구 호출 없이 스키마 맥락을 발견할 수 있습니다. 리소스는 도구와 동일한 읽기 전용 카탈로그 쿼리를 재사용합니다 — 데이터 접근 범위는 늘어나지 않습니다.
+
+| 리소스 URI | 설명 |
+|--------------|------|
+| `cubrid://schema` | 전체 스키마 인덱스: 모든 사용자 테이블과 테이블별 리소스 URI |
+| `cubrid://schema/{table}` | 테이블별 메타데이터(컬럼, 기본 키, 인덱스) — `describe_table`과 동일 |
+
+둘 다 `application/json`을 반환합니다. `{table}`의 테이블 이름은 URI 템플릿 매칭으로 퍼센트 디코딩되며, 알 수 없거나 시스템 테이블이면 리소스 읽기 오류가 발생합니다(`describe_table` 도구와 동일한 동작).
+
+## 프롬프트
+
+서버는 MCP **프롬프트 템플릿**을 노출합니다 — 흔한 조회 작업의 안내 전용 시작점입니다. 각 프롬프트는 클라이언트에게 어느 읽기 전용 도구를 어떤 순서로 호출할지 알려주는 텍스트를 반환합니다. 프롬프트는 데이터베이스에 접근하거나 SQL을 실행하지 않으며, 데이터 접근 범위를 늘리지 않고, 인자는 신뢰할 수 없는 데이터로 취급됩니다.
+
+| 프롬프트 | 인자 | 설명 |
+|--------|-----------|------|
+| `summarize_table` | `table` | 테이블을 설명한 뒤 제한된 읽기 전용 쿼리로 샘플 조회 |
+| `explain_query` | `sql` | `SELECT`/`WITH`의 실행 계획을 얻고 해석 |
+| `inspect_schema` | (없음) | 읽기 전용 도구들로 전체 스키마 개요 작성 |
+| `find_index_candidates` | `table` | 테이블의 인덱스 커버리지 검토 |

--- a/docs/ko/TROUBLESHOOTING.md
+++ b/docs/ko/TROUBLESHOOTING.md
@@ -1,0 +1,54 @@
+# 문제 해결 (한국어)
+
+> 🌐 [TROUBLESHOOTING.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/docs/TROUBLESHOOTING.md)의 번역입니다. 영어 원문이 표준이며, 페이지 번역은 경고 수준의 동기화 규칙을 따릅니다.
+
+증상 → 원인 → 해결 순으로 정리했습니다.
+
+## 클라이언트가 서버에 연결되지 않음
+
+**증상:** MCP 클라이언트가 서버를 실패 또는 사용 불가로 표시함.
+
+- **`uvx` 없음.** 클라이언트는 `uvx cubrid-mcp-server`를 실행합니다 — [uv](https://docs.astral.sh/uv/)를 설치해 클라이언트의 `PATH`에 두거나, 클라이언트 설정에 절대 경로를 사용하세요(`"command": "/home/you/.local/bin/uvx"`).
+- **환경 변수 누락.** `CUBRID_HOST`, `CUBRID_USER`, `CUBRID_PASSWORD`, `CUBRID_DATABASE`는 클라이언트의 `env` 블록에 있어야 합니다 — 터미널의 `export`는 Claude Desktop 같은 GUI 앱에 보이지 않습니다.
+- **설정 파일 위치.** Claude Desktop은 `~/Library/Application Support/Claude/claude_desktop_config.json`, Claude Code는 프로젝트 루트의 `.mcp.json`, Cursor는 `.cursor/mcp.json`을 읽습니다. 수정 후에는 클라이언트를 재시작하세요.
+
+## CUBRID 연결 거부
+
+**증상:** 도구가 연결 또는 운영 오류로 실패함.
+
+- **포트.** 서버는 CUBRID **브로커**의 33000 포트(`CUBRID_PORT`)에 연결합니다 — 매니저 포트 1523이 아닙니다.
+- **데이터베이스가 없음.** 먼저 생성하세요(`cubrid createdb`) 또는 `CUBRID_DATABASE`를 기존 데이터베이스로 지정하세요.
+- **CUBRID 기동 중.** 새 CUBRID 컨테이너는 접속 수락까지 시간이 걸립니다 — 브로커가 TCP를 열고 엔진이 준비되는 사이에 틈이 있습니다. 쿼리 전에 준비를 기다리세요(docker-compose 헬스체크 등). `health_check`가 요청 시점에 연결을 확인해 줍니다.
+- **자격 증명.** `CUBRID_USER`/`CUBRID_PASSWORD`가 유효해야 합니다. 로컬 docker에서는 빈 비밀번호의 `dba`가 흔합니다.
+
+## 쿼리 권한 거부
+
+**증상:** `SELECT` 문에서 권한 오류.
+
+CUBRID 사용자에게 권한이 없습니다. CUBRID는 **테이블 단위**로 권한을 부여합니다 — 스키마 전체 `db.*` 부여는 없습니다. 사용자를 만들고 모델이 읽을 각 테이블에 `SELECT`를 부여하세요. [보안 모델](SECURITY_MODEL.ko.md#계층-1--데이터베이스-권한-필수) 참고.
+
+## 읽기 전용 거부
+
+**증상:** `execute_query`가 문장을 거부함.
+
+설계된 동작입니다. 화이트리스트는 `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `EXPLAIN`, `WITH`만 허용하며 다중 문장은 항상 거부됩니다. 정말 다른 문장이 필요하면 먼저 읽기 전용 DB 사용자를 배치한 뒤 `CUBRID_MCP_READONLY=0`을 고려하세요 — 쓰기는 화이트리스트를 끄는 대신 옵트인 쓰기 모드를 사용하세요.
+
+## 출력이 잘린 것처럼 보임
+
+**증상:** `execute_query` 결과가 갑자기 끝나거나 잘림 표시가 있음.
+
+행·글자 상한은 모델의 컨텍스트 창을 보호합니다. 더 필요하면 `CUBRID_MCP_MAX_ROWS`(기본 1000) 또는 `CUBRID_MCP_MAX_CHARS`(기본 4000)를 올리거나, 쿼리를 좁히세요.
+
+## 쿼리 타임아웃 의미
+
+**증상:** 오래 걸리는 쿼리가 약 30초에 중단됨.
+
+`CUBRID_MCP_QUERY_TIMEOUT`(기본 30)은 **소켓 읽기 타임아웃**이지 서버 측 문장 타임아웃이 아닙니다: 서버가 이 시간 안에 데이터를 보내지 않으면 쿼리가 중단되고 연결이 재설정됩니다. 워크로드에 맞게 조정하세요(연결별 `CUBRID_<NAME>_MCP_QUERY_TIMEOUT`도 가능).
+
+## 로그가 안 보임 / 서버 출력이 JSON 깨진 것처럼 보임
+
+서버는 MCP stdio를 사용합니다: `stdout`은 프로토콜 스트림이고 **모든 로그는 stderr**로 갑니다. 클라이언트의 MCP 로그 창을 보거나(직접 실행 시 `2>server.log` 리다이렉트) 확인하세요. 커스터마이즈에서 `print()`를 stdout에 절대 추가하지 마세요 — 프로토콜 스트림이 오염되어 연결이 깨집니다.
+
+## 감사 로그가 안 남음
+
+`CUBRID_MCP_AUDIT_LOG=1`을 설정하세요(옵트인, 기본 꺼짐). 멀티커넥션에서는 연결별로 `CUBRID_<NAME>_MCP_AUDIT_LOG`로 켭니다. 기록은 **stderr**의 JSON 라인입니다 — stdout에는 절대 나오지 않습니다. [보안 모델](SECURITY_MODEL.ko.md#계층-4--감사-로그-옵트인) 참고.

--- a/docs/ko/quickstart.md
+++ b/docs/ko/quickstart.md
@@ -1,0 +1,136 @@
+# 빠른 시작 (한국어)
+
+> 🌐 [quickstart.md](https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/docs/quickstart.md)의 번역입니다. 영어 원문이 표준이며, 페이지 번역은 커뮤니티 기여 번역과 같은 경고 수준의 동기화 규칙을 따릅니다.
+
+CUBRID MCP 서버를 구성하고 LLM 클라이언트를 연결하는 방법을 몇 분 안에 안내합니다.
+
+## 1. 설정
+
+필수 환경 변수:
+
+```bash
+export CUBRID_HOST=localhost
+export CUBRID_PORT=33000        # 선택, 기본값: 33000
+export CUBRID_USER=readonly_user   # SELECT 권한만 가진 CUBRID 사용자 (보안 모델 참고)
+export CUBRID_PASSWORD=secret
+export CUBRID_DATABASE=mydb
+```
+
+선택 설정:
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `CUBRID_MCP_READONLY` | `1` | 읽기 전용 SQL 화이트리스트 강제 |
+| `CUBRID_MCP_MAX_CHARS` | `4000` | 쿼리 출력 최대 글자 수 |
+| `CUBRID_MCP_MAX_ROWS` | `1000` | `execute_query` 최대 행 수 (초과 시 잘림) |
+| `CUBRID_MCP_MAX_SQL_LENGTH` | `65536` | 제출 가능한 SQL 최대 길이 (글자 수) |
+| `CUBRID_MCP_QUERY_TIMEOUT` | `30` | 문장별 소켓 읽기 타임아아웃(초). 서버가 이 시간 내에 데이터를 보내지 않으면 쿼리가 중단되고 연결이 재설정됩니다. 서버 측 문장 타임아웃이 아닙니다. |
+| `CUBRID_MCP_AUDIT_LOG` | `0` | 옵트인 감사 로그. 활성화 시 실행된 문장마다 재던션-safe JSON 기록을 **stderr**에 출력 (연결별 적용: `CUBRID_<NAME>_MCP_AUDIT_LOG`) |
+| `CUBRID_MCP_WRITE` | `0` | 옵트인 쓰기 모드. `1`로 설정하면 단일 DML용 `execute_write` 도구가 등록됩니다 (연결별 적용: `CUBRID_<NAME>_MCP_WRITE`). 기본은 꺼짐 |
+
+## 2. 실행
+
+PyPI에서 [`uvx`](https://docs.astral.sh/uv/guides/tools/)로 바로 실행:
+
+```bash
+uvx cubrid-mcp-server
+```
+
+또는 `pipx`로:
+
+```bash
+pipx run cubrid-mcp-server
+```
+
+소스에서 실행:
+
+```bash
+git clone https://github.com/cubrid-lab/cubrid-mcp-server.git
+cd cubrid-mcp-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cubrid-mcp-server
+```
+
+서버는 MCP를 stdio로 통신합니다. 터미널에서 단독 실행이 목적이 아니라, MCP 클라이언트에 서버로 등록하는 것이 사용 방법입니다.
+
+## 3. 클라이언트 연결
+
+### Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+프로젝트 루트의 `.mcp.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+`.cursor/mcp.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "cubrid": {
+      "command": "uvx",
+      "args": ["cubrid-mcp-server"],
+      "env": {
+        "CUBRID_HOST": "localhost",
+        "CUBRID_USER": "readonly_user",
+        "CUBRID_PASSWORD": "secret",
+        "CUBRID_DATABASE": "mydb"
+      }
+    }
+  }
+}
+```
+
+## 4. 첫 쿼리
+
+클라이언트가 연결되면 다음을 시도해 보세요:
+
+1. *"이 DB에 어떤 테이블이 있어?"* — 클라이언트가 `all_table_names`를 호출합니다.
+2. *"`orders` 테이블 구조 보여줘"* — `describe_table`이 컬럼·기본 키·인덱스를 반환합니다.
+3. *"매출 상위 5개 상품은?"* — `execute_query`가 `SELECT`를 실행하고 잘림 처리된, 컨텍스트 안전한 출력을 반환합니다.
+
+모델에게 테이블 삭제를 요청하면 읽기 전용 화이트리스트가 거부합니다 — 이 강제는 프롬프트가 아니라 서버에 있습니다. 전체 설계는 [보안 모델](SECURITY_MODEL.ko.md)을 참고하세요.
+
+## 다음 단계
+
+- [도구 참조](TOOLS.ko.md) — 모든 도구·리소스·프롬프트
+- [멀티커넥션](MULTI_CONNECTION.ko.md) — 하나의 프로세스로 여러 데이터베이스 서빙
+- [문제 해결](TROUBLESHOOTING.ko.md) — 연결이 안 될 때

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,13 @@ nav:
       - Troubleshooting: TROUBLESHOOTING.md
   - Project:
       - Translations:
-          - 한국어: README.ko.md
+          - 한국어 README: README.ko.md
+          - 한국어 문서:
+              - 빠른 시작: ko/quickstart.md
+              - 도구 참조: ko/TOOLS.md
+              - 보안 모델: ko/SECURITY_MODEL.md
+              - 멀티커넥션: ko/MULTI_CONNECTION.md
+              - 문제 해결: ko/TROUBLESHOOTING.md
   - Changelog: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CHANGELOG.md
   - Contributing: https://github.com/cubrid-lab/cubrid-mcp-server/blob/main/CONTRIBUTING.md
 


### PR DESCRIPTION
Closes #160 (병합은 유지관리자 한국어 리뷰 후 — **자동 머지 금지**).

- `docs/ko/{quickstart,TOOLS,SECURITY_MODEL,MULTI_CONNECTION,TROUBLESHOOTING}.md` — 원문 링크 마커 포함, 한국어 페이지 간 상호링크(.ko.md 상대경로)
- nav: Project → Translations → 한국어 문서 5페이지
- `mkdocs build --strict` 통과
- 동기화 정책: 페이지 번역은 경고 수준(README.ko 하드 게이트 유지)