### PR TITLE
docs: embed demo GIF in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Documentation
+- **Demo GIF embedded in README** — programmatic MCP server interaction showing initialize → tools list → read-only whitelist.
 - **CUBRID Skills — domain knowledge + expert prompts (#162)** — the server now ships with a knowledge layer so LLM clients can use CUBRID effectively without prior CUBRID expertise: (1) server instructions sent on connect (CUBRID dialect primer), (2) enriched tool descriptions with CUBRID-specific hints (LIMIT syntax, SHOW TRACE, USING INDEX), (3) five domain-knowledge resources (`cubrid://agent-guide` + 4 topic guides on sql-dialect/types/performance/collections), (4) five expert prompts (`optimize_query`, `migrate_from_mysql`, `explore_unknown_db`, `safe_data_analysis`, `write_cubrid_sql`). 10 new tests. Oracle-validated design.
 - **Oracle post-implementation review fixes**: corrected LIMIT syntax claim (comma form is valid), acknowledged NOW()/CURRENT_DATE as supported aliases, corrected SERIAL nomenclature (objects not types), replaced undocumented collection methods with standard operators, hedged performance claims, added 'for human approval — do not execute' guardrails to DDL suggestions, distinguished read-only vs DML validation in write_cubrid_sql prompt. 5 regression tests added (284 total).
 - **한국어 문서 페이지 (#160)** — 사이트 문서 5개 페이지(quickstart·TOOLS·보안 모델·멀티커넥션·문제 해결)의 한국어 번역을 `docs/ko/`에 추가하고 Project → Translations → 한국어 문서로 노출. 페이지 번역은 경고 수준 동기화(README.ko의 하드 게이트는 유지).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [CUBRID](
 
 <!-- mcp-name: io.github.cubrid-lab/cubrid-mcp-server -->
 
+<img src="docs/demo.gif" alt="cubrid-mcp-server demo" width="100%"/>
+
 ## Features
 
 | Tool | Description |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -5,6 +5,8 @@
 
 [CUBRID](https://www.cubrid.org/) 데이터베이스를 위한 [Model Context Protocol](https://modelcontextprotocol.io) 서버. LLM 클라이언트가 순수 Python 드라이버 [pycubrid](https://pypi.org/project/pycubrid/)를 통해 스키마를 안전하게 조회하고 **읽기 전용** 쿼리를 실행할 수 있습니다.
 
+<img src="https://github.com/cubrid-lab/cubrid-mcp-server/raw/main/docs/demo.gif" alt="MCP 서버 데모" width="100%"/>
+
 ## 기능
 
 | 도구 | 설명 |


### PR DESCRIPTION
Embeds the auto-generated terminal demo GIF directly in the README, following the pattern used by HTTPie (34k stars) and Streamlit (37k stars).

The GIF shows the key value proposition at a glance — no need to read the docs to understand what this package does.

Generated from `demos/*.json` via `demos/render_gif.py` (both committed for reproducibility).